### PR TITLE
GRUF-7: Add outer_around hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog for the gruf gem. This includes internal history before the gem was made.
 
+h4. 0.12.2
+
+- Add outer_around hook for wrapping the entire call chain
+
 h4. 0.12.1
 
 - Add ability to specify a separate gRPC logger from the Gruf logger

--- a/lib/gruf/hooks/registry.rb
+++ b/lib/gruf/hooks/registry.rb
@@ -51,7 +51,7 @@ module Gruf
           hook.class_eval(&block) if block_given?
 
           # all hooks require either the before, after, or around method
-          raise NoMethodError unless hook.method_defined?(:before) || hook.method_defined?(:after) || hook.method_defined?(:around)
+          raise NoMethodError unless hook.method_defined?(:before) || hook.method_defined?(:after) || hook.method_defined?(:around) || hook.method_defined?(:outer_around)
 
           raise HookDescendantError, "Hooks must descend from #{base}" unless hook.ancestors.include?(base)
 

--- a/spec/gruf/rpc/hooks_spec.rb
+++ b/spec/gruf/rpc/hooks_spec.rb
@@ -1,0 +1,285 @@
+require 'spec_helper'
+
+describe Gruf::Service do
+  let(:endpoint) { ThingService.new }
+  let(:id) { 1 }
+  let(:req) { ::Rpc::GetThingRequest.new(id: id) }
+  let(:resp) { ::Rpc::GetThingResponse.new(id: id) }
+  let(:call_signature) { :get_thing }
+  let(:active_call) { double(:active_call, output_metadata: {}, metadata: {})}
+
+  subject { endpoint }
+
+  describe '.before_call' do
+    subject { endpoint.before_call(call_signature, req, active_call) }
+
+    it 'should exist on the service' do
+      expect(endpoint.respond_to?(:before_call)).to be_truthy
+    end
+
+    context 'with one hook registered' do
+      context 'that is a successful hook' do
+        before do
+          Gruf::Hooks::Registry.clear
+          Gruf::Hooks::Registry.add(:before_hook_1, BeforeHook1)
+        end
+
+        it 'should call the before method on the hook' do
+          expect(Gruf::Hooks::Registry.count).to eq 1
+          expect(BeforeHook1).to receive(:verify).once, 'BeforeHook1 did not call .before'
+          subject
+        end
+      end
+
+      context 'that is calls an exception' do
+        before do
+          Gruf::Hooks::Registry.clear
+          Gruf::Hooks::Registry.add(:before_hook_1, BeforeExceptionHook1)
+        end
+
+        it 'should call the before method on the hook and raise the exception' do
+          expect(Gruf::Hooks::Registry.count).to eq 1
+          expect(BeforeExceptionHook1).to receive(:verify).once, 'BeforeExceptionHook1 did not call .before'
+          expect { subject }.to raise_error(StandardError)
+        end
+      end
+    end
+
+    context 'with no hooks registered' do
+      before do
+        Gruf::Hooks::Registry.clear
+      end
+
+      it 'should just return normally' do
+        expect(Gruf::Hooks::Registry.count).to eq 0
+        expect(BeforeHook1).to_not receive(:verify), 'BeforeHook1 improperly called .before'
+        subject
+      end
+    end
+
+    context 'with multiple hooks registered' do
+      context 'and they all are successful' do
+        before do
+          Gruf::Hooks::Registry.clear
+          Gruf::Hooks::Registry.add(:around_hook_1, AroundHook1)
+          Gruf::Hooks::Registry.add(:before_hook_1, BeforeHook1)
+          Gruf::Hooks::Registry.add(:before_hook_2, BeforeHook2)
+          Gruf::Hooks::Registry.add(:after_hook_1, AfterHook1)
+          Gruf::Hooks::Registry.add(:before_hook_3, BeforeHook3)
+          Gruf::Hooks::Registry.add(:after_hook_2, AfterHook2)
+        end
+
+        it 'should call the before method on all before hooks' do
+          expect(Gruf::Hooks::Registry.count).to eq 6
+          expect(AroundHook1).to_not receive(:verify), 'AroundHook1 was improperly called'
+          expect(BeforeHook1).to receive(:verify).once, 'BeforeHook1 did not call .before'
+          expect(BeforeHook2).to receive(:verify).once, 'BeforeHook2 did not call .before'
+          expect(AfterHook1).to_not receive(:verify), 'AfterHook1 was improperly called'
+          expect(BeforeHook3).to receive(:verify).once, 'BeforeHook3 did not call .before'
+          expect(AfterHook2).to_not receive(:verify), 'AfterHook2 was improperly called'
+          subject
+        end
+      end
+
+      context 'and the first before hook raises an exception' do
+        before do
+          Gruf::Hooks::Registry.clear
+          Gruf::Hooks::Registry.add(:before_hook_1, BeforeExceptionHook1)
+          Gruf::Hooks::Registry.add(:before_hook_2, BeforeHook2)
+        end
+
+        it 'should raise an exception and not call the second hook' do
+          expect(Gruf::Hooks::Registry.count).to eq 2
+          expect(BeforeExceptionHook1).to receive(:verify).once, 'BeforeExceptionHook1 did not call .before'
+          expect(BeforeHook2).to_not receive(:verify), 'BeforeHook2 should not have received .before'
+          expect { subject }.to raise_error(StandardError)
+        end
+      end
+
+      context 'and the second before hook raises an exception' do
+        before do
+          Gruf::Hooks::Registry.clear
+          Gruf::Hooks::Registry.add(:before_hook_1, BeforeHook1)
+          Gruf::Hooks::Registry.add(:before_hook_2, BeforeExceptionHook1)
+        end
+
+        it 'should raise an exception but still call the first hook' do
+          expect(Gruf::Hooks::Registry.count).to eq 2
+          expect(BeforeHook1).to receive(:verify).once, 'BeforeHook1 did not have call .before'
+          expect(BeforeExceptionHook1).to receive(:verify).once, 'BeforeExceptionHook1 did not call .before'
+          expect { subject }.to raise_error(StandardError)
+        end
+      end
+    end
+  end
+
+  describe '.after_call' do
+    subject { endpoint.after_call(true, resp, call_signature, req, active_call) }
+
+    it 'should exist on the service' do
+      expect(endpoint.respond_to?(:after_call)).to be_truthy
+    end
+
+    context 'with a hook registered' do
+      before do
+        Gruf::Hooks::Registry.clear
+        Gruf::Hooks::Registry.add(:after_hook_1, AfterHook1)
+      end
+
+      it 'should call the after method on the hook' do
+        expect(Gruf::Hooks::Registry.count).to eq 1
+        expect(AfterHook1).to receive(:verify).once, 'AfterHook1 did not call .after'
+        subject
+      end
+    end
+
+    context 'with multiple hooks registered' do
+      before do
+        Gruf::Hooks::Registry.clear
+        Gruf::Hooks::Registry.add(:around_hook_1, AroundHook1)
+        Gruf::Hooks::Registry.add(:after_hook_1, AfterHook1)
+        Gruf::Hooks::Registry.add(:after_hook_2, AfterHook2)
+        Gruf::Hooks::Registry.add(:before_hook_1, BeforeHook1)
+        Gruf::Hooks::Registry.add(:after_hook_3, AfterHook3)
+        Gruf::Hooks::Registry.add(:before_hook_2, BeforeHook2)
+      end
+
+      it 'should call the before method on all after hooks' do
+        expect(Gruf::Hooks::Registry.count).to eq 6
+        expect(AroundHook1).to_not receive(:verify), 'AroundHook1 was improperly called'
+        expect(AfterHook1).to receive(:verify).once, 'AfterHook1 did not call .before'
+        expect(AfterHook2).to receive(:verify).once, 'AfterHook2 did not call .before'
+        expect(BeforeHook1).to_not receive(:verify), 'BeforeHook1 was improperly called'
+        expect(AfterHook3).to receive(:verify).once, 'AfterHook3 did not call .before'
+        expect(BeforeHook2).to_not receive(:verify), 'BeforeHook2 was improperly called'
+        subject
+      end
+    end
+  end
+
+  describe '.around_call' do
+    subject { endpoint.around_call(call_signature, req, active_call) { Math.exp(2); true } }
+
+    it 'should exist on the service' do
+      expect(endpoint.respond_to?(:around_call)).to be_truthy
+    end
+
+    context 'with a hook registered' do
+      before do
+        Gruf::Hooks::Registry.clear
+        Gruf::Hooks::Registry.add(:around_hook_1, AroundHook1)
+      end
+
+      it 'should call the around method on the hook' do
+        expect(Gruf::Hooks::Registry.count).to eq 1
+        expect(AroundHook1).to receive(:verify).once, 'AroundHook1 did not call .around'
+        subject
+      end
+
+      it 'should only call the actual request once' do
+        expect(Math).to receive(:exp).once
+        subject
+      end
+    end
+
+    context 'with no hooks registered' do
+      before do
+        Gruf::Hooks::Registry.clear
+      end
+
+      it 'should just call the proc' do
+        expect(Math).to receive(:exp).once
+        subject
+      end
+    end
+
+    context 'with multiple hooks registered' do
+      before do
+        Gruf::Hooks::Registry.clear
+        Gruf::Hooks::Registry.add(:around_hook_1, AroundHook1)
+        Gruf::Hooks::Registry.add(:around_hook_2, AroundHook2)
+        Gruf::Hooks::Registry.add(:before_hook_1, BeforeHook1)
+        Gruf::Hooks::Registry.add(:around_hook_3, AroundHook3)
+        Gruf::Hooks::Registry.add(:after_hook_1, AfterHook1)
+      end
+
+      it 'should call the around method on each hook' do
+        expect(Gruf::Hooks::Registry.count).to eq 5
+        expect(AroundHook1).to receive(:verify).once, 'AroundHook1 did not call .around'
+        expect(AroundHook2).to receive(:verify).once, 'AroundHook2 did not call .around'
+        expect(BeforeHook1).to_not receive(:verify), 'BeforeHook1 improperly received call'
+        expect(AroundHook3).to receive(:verify).once, 'AroundHook3 did not call .around'
+        expect(AfterHook1).to_not receive(:verify), 'AfterHook1 improperly received call'
+        subject
+      end
+
+      it 'should only call the actual request once' do
+        expect(Math).to receive(:exp).once
+        subject
+      end
+    end
+  end
+
+  describe '.outer_around_call' do
+    subject { endpoint.outer_around_call(call_signature, req, active_call) { Math.exp(2); true } }
+
+    it 'should exist on the service' do
+      expect(endpoint.respond_to?(:outer_around_call)).to be_truthy
+    end
+
+    context 'with a hook registered' do
+      before do
+        Gruf::Hooks::Registry.clear
+        Gruf::Hooks::Registry.add(:outer_around_hook_1, OuterAroundHook1)
+      end
+
+      it 'should call the around method on the hook' do
+        expect(Gruf::Hooks::Registry.count).to eq 1
+        expect(OuterAroundHook1).to receive(:verify).once, 'OuterAroundHook1 did not call .around'
+        subject
+      end
+
+      it 'should only call the actual request once' do
+        expect(Math).to receive(:exp).once
+        subject
+      end
+    end
+
+    context 'with no hooks registered' do
+      before do
+        Gruf::Hooks::Registry.clear
+      end
+
+      it 'should just call the proc' do
+        expect(Math).to receive(:exp).once
+        subject
+      end
+    end
+
+    context 'with multiple hooks registered' do
+      before do
+        Gruf::Hooks::Registry.clear
+        Gruf::Hooks::Registry.add(:outer_around_hook_1, OuterAroundHook1)
+        Gruf::Hooks::Registry.add(:outer_around_hook_2, OuterAroundHook2)
+        Gruf::Hooks::Registry.add(:before_hook_1, BeforeHook1)
+        Gruf::Hooks::Registry.add(:outer_around_hook_3, OuterAroundHook3)
+        Gruf::Hooks::Registry.add(:after_hook_1, AfterHook1)
+      end
+
+      it 'should call the outer_around method on each appropriate hook' do
+        expect(Gruf::Hooks::Registry.count).to eq 5
+        expect(OuterAroundHook1).to receive(:verify).once, 'OuterAroundHook1 did not call .around'
+        expect(OuterAroundHook2).to receive(:verify).once, 'OuterAroundHook2 did not call .around'
+        expect(BeforeHook1).to_not receive(:verify), 'BeforeHook1 improperly received call'
+        expect(OuterAroundHook3).to receive(:verify).once, 'OuterAroundHook3 did not call .around'
+        expect(AfterHook1).to_not receive(:verify), 'AfterHook1 improperly received call'
+        subject
+      end
+
+      it 'should only call the actual request once' do
+        expect(Math).to receive(:exp).once
+        subject
+      end
+    end
+  end
+end

--- a/spec/support/grpc_server.rb
+++ b/spec/support/grpc_server.rb
@@ -98,6 +98,7 @@ class ThingService < Rpc::ThingService::Service
   include Gruf::Service
 
   def get_thing(req, _call)
+    Math.sqrt(4) # used for testing
     ::Rpc::GetThingResponse.new(id: req.id)
   end
 

--- a/spec/support/hooks.rb
+++ b/spec/support/hooks.rb
@@ -13,7 +13,12 @@ class TestAllHook1 < TestHook
     true
   end
 
-  def around(_call_signature, _req, _call, &block)
+  def around(_call_signature, _req, _call, &_)
+    self.class.verify
+    yield
+  end
+
+  def outer_around(_call_signature, _req, _call, &_)
     self.class.verify
     yield
   end
@@ -45,26 +50,38 @@ class BeforeHook3 < TestHook
     true
   end
 end
+class BeforeExceptionHook1 < TestHook
+  def before(_cs, _r, _c)
+    self.class.verify
+    raise StandardError, 'Exception!'
+  end
+end
 
 ##########################################################################################
 # AROUND HOOKS
 ##########################################################################################
 class AroundHook1 < TestHook
-  def around(_cs, _r, _c, &block)
+  def around(_cs, _r, _c, &_)
     self.class.verify
     yield
   end
 end
 class AroundHook2 < TestHook
-  def around(_cs, _r, _c, &block)
+  def around(_cs, _r, _c, &_)
     self.class.verify
     yield
   end
 end
 class AroundHook3 < TestHook
-  def around(_cs, _r, _c, &block)
+  def around(_cs, _r, _c, &_)
     self.class.verify
     yield
+  end
+end
+class AroundExceptionHook1 < TestHook
+  def around(_cs, _r, _c, &_)
+    self.class.verify
+    raise StandardError, 'Exception!'
   end
 end
 
@@ -87,5 +104,39 @@ class AfterHook3 < TestHook
   def after(_s, _rsp, _cs, _req, _c)
     self.class.verify
     true
+  end
+end
+class AfterExceptionHook1 < TestHook
+  def before(_s, _rsp, _cs, _req, _c)
+    self.class.verify
+    raise StandardError, 'Exception!'
+  end
+end
+
+##########################################################################################
+# OUTER AROUND HOOKS
+##########################################################################################
+class OuterAroundHook1 < TestHook
+  def outer_around(_cs, _r, _c, &_)
+    self.class.verify
+    yield
+  end
+end
+class OuterAroundHook2 < TestHook
+  def outer_around(_cs, _r, _c, &_)
+    self.class.verify
+    yield
+  end
+end
+class OuterAroundHook3 < TestHook
+  def outer_around(_cs, _r, _c, &_)
+    self.class.verify
+    yield
+  end
+end
+class OuterAroundExceptionHook1 < TestHook
+  def around(_cs, _r, _c, &_)
+    self.class.verify
+    raise StandardError, 'Exception!'
   end
 end


### PR DESCRIPTION
Adds an `outer_around` hook for wrapping the entire call chain: it wraps the before, around, request itself, and after calls, so as to provide a fuller wrap that can be used for performance metrics.

Note: It's important to note that the authentication step happens immediately before the first _before_ hook is called, so don't perform any actions that you want behind authentication in outer around hooks, as they are not called with authentication.

----

@bigcommerce/services @pedelman @junedkazi 