### PR TITLE
Update configuration and global exception handler to not pass e.message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,47 +1,53 @@
 Changelog for the gruf gem. This includes internal history before the gem was made.
 
-h3. 1.1.0
+### Pending release
+
+- Add ability to turn off sending exception message on uncaught exception.
+- Add configuration to set the error message when an uncaught exception is
+  handled by gruf.
+
+### 1.1.0
 
 - Add the ability for call options to the client, which enables deadline setting 
 
-h3. 1.0.0
+### 1.0.0
 
 - Bump gRPC to 1.4 
 
-h3. 0.14.2
+### 0.14.2
 
 - Added rubocop style-guide checks
 
-h3. 0.14.1
+### 0.14.1
 
 - Updated license to MIT
 
-h3. 0.14.0
+### 0.14.0
 
 - Send gRPC status 16 (Unauthenticated) instead of 7 (PermissionDenied) when authentication fails
 
-h3. 0.13.0
+### 0.13.0
 
 - Move to gRPC 1.3.4
 
-h4. 0.12.2
+### 0.12.2
 
 - Add outer_around hook for wrapping the entire call chain
 
-h4. 0.12.1
+### 0.12.1
 
 - Add ability to specify a separate gRPC logger from the Gruf logger
 
-h3. 0.12.0
+### 0.12.0
 
 - Add ability to run multiple around hooks
 - Fix bug with error handling that caused error messages to repeat across streams 
 
-h3. 0.11.5
+### 0.11.5
 
 - Fix issue with around hook
 
-h3. 0.11.4
+### 0.11.4
 
 - Add catchall rescue handler to capture uncaught exceptions and
   raise a GRPC::Internal error.
@@ -49,37 +55,37 @@ h3. 0.11.4
   will call Service.set_debug_info with the exception backtrace
   if an uncaught exception occurs.
 
-h3. 0.11.3
+### 0.11.3
 
 - Pass the service instance into hooks for reference
 
-h3. 0.11.2
+### 0.11.2
 
 - Ensure timer is measuring in milliseconds
 
-h3. 0.11.1
+### 0.11.1
 
 - Fix issue with interceptor and call signature
 
-h3. 0.11.0
+### 0.11.0
 
 - Add instrumentation layer and ability to register new instrumentors
 - Add out-of-the-box statsd instrumentation support
 
-h3. 0.10.0
+### 0.10.0
 
 - Rename Gruf::Endpoint to Gruf::Service
 - Make services auto-mount to server upon declaration
 
-h3. 0.9.2
+### 0.9.2
 
 - Support mount command on services to allow automatic setup on the server
 - Cleanup and consolidate binstub to prevent need for custom binstub per-app
 
-h3. 0.9.1
+### 0.9.1
 
 - Relax licensing to a clean BSD license
 
-h3. 0.9.0
+### 0.9.0
 
 - Initial public release

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -38,7 +38,9 @@ module Gruf
       authorization_metadata_key: 'authorization',
       append_server_errors_to_trailing_metadata: true,
       use_default_hooks: true,
-      backtrace_on_error: false
+      backtrace_on_error: false,
+      use_exception_message: true,
+      internal_error_message: 'Internal Server Error'
     }.freeze
 
     attr_accessor *VALID_CONFIG_KEYS.keys

--- a/lib/gruf/service.rb
+++ b/lib/gruf/service.rb
@@ -228,7 +228,8 @@ module Gruf
     rescue => e
       raise e if e.is_a?(GRPC::BadStatus)
       set_debug_info(e.message, e.backtrace) if Gruf.backtrace_on_error
-      fail!(req, call, :internal, :unknown, e.message)
+      error_message = Gruf.use_exception_message ? e.message : Gruf.internal_error_message
+      fail!(req, call, :internal, :unknown, error_message)
     end
 
     ##


### PR DESCRIPTION
## What? Why?

Sending along an uncaught exception message by default can be considered insecure. This can leak server information to clients of the service unintentionally. 

This PR will set the error_message for an uncaught exception and allow a user to both modify the error message as well as enable sending the exception message if that is intended behavior.

## How was it tested?

Rspec tests have been added.