### PR TITLE
Allow GRPC::RpcServer configuration

### DIFF
--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -22,6 +22,7 @@ module Gruf
     VALID_CONFIG_KEYS = {
       root_path: '',
       server_binding_url: '0.0.0.0:9001',
+      server_options: {},
       authentication_options: {},
       instrumentation_options: {},
       hook_options: {},

--- a/lib/gruf/server.rb
+++ b/lib/gruf/server.rb
@@ -41,7 +41,7 @@ module Gruf
     # :nocov:
     def start!
       logger.info { 'Booting gRPC Server...' }
-      server = GRPC::RpcServer.new
+      server = GRPC::RpcServer.new(Gruf.server_options)
       server.add_http2_port Gruf.server_binding_url, ssl_credentials
       services.each do |s|
         server.handle(s)

--- a/spec/gruf/server_spec.rb
+++ b/spec/gruf/server_spec.rb
@@ -78,4 +78,40 @@ describe Gruf::Server do
       end
     end
   end
+
+  describe '#start!' do
+    let(:server_mock) { double(GRPC::RpcServer, add_http2_port: nil, run_till_terminated: nil) }
+
+    context 'when server_options passed' do
+      let(:configuration) { { pool_size: 5 } }
+
+      before do
+        Gruf.configure do |c|
+          c.server_options = configuration
+          c.services = []
+        end
+      end
+
+      it 'runs server with given configuration' do
+        expect(GRPC::RpcServer).to receive(:new).with(configuration).and_return(server_mock)
+
+        gruf_server.start!
+      end
+    end
+
+    context 'when no server_options passed' do
+      before do
+        Gruf.configure do |c|
+          c.server_options = {}
+          c.services = []
+        end
+      end
+
+      it 'runs server with empty configuration' do
+        expect(GRPC::RpcServer).to receive(:new).with({}).and_return(server_mock)
+
+        gruf_server.start!
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What? Why?
Ability to configure `GRPC::RpcServer` (e.g. `pool_size`) was missing (http://www.rubydoc.info/gems/grpc/GRPC/RpcServer#initialize-instance_method). 

## How was it tested?
Specs and running `bundle exec gruf` with and without additional config.
