### PR TITLE
Prevent Gruf::Server from loading non-service files

### DIFF
--- a/lib/gruf.rb
+++ b/lib/gruf.rb
@@ -31,6 +31,7 @@ require_relative 'gruf/timer'
 require_relative 'gruf/response'
 require_relative 'gruf/error'
 require_relative 'gruf/client'
+require_relative 'gruf/service_loader'
 require_relative 'gruf/server'
 
 ##

--- a/lib/gruf/service_loader.rb
+++ b/lib/gruf/service_loader.rb
@@ -1,0 +1,65 @@
+# coding: utf-8
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  ##
+  # Register and require Gruf services so they can be served.
+  #
+  class ServiceLoader
+    include Gruf::Loggable
+
+    SERVICE_IDENTIFIER = 'include Gruf::Service'.freeze
+
+    attr_accessor :services, :load_path
+
+    ##
+    # @param [Array<Class>] services The services that should be served
+    # @param [String] load_path The directory the Gruf::Service files reside
+    #
+    def initialize(services: [], load_path: Gruf.servers_path)
+      @load_path = load_path
+      register_services(services)
+    end
+
+    ##
+    # Require all Gruf::Service's in the load_path. Files in the load_path that aren't
+    # identified as Gruf::Service's will not be required explicitly.
+    #
+    def require_services
+      files_in_load_path = Dir["#{load_path}/**/*.rb"]
+      files_in_load_path.each do |f|
+        file_text = File.read(f)
+
+        if file_text.include?(SERVICE_IDENTIFIER)
+          logger.info "- Loading gRPC service file: #{f}"
+          require f
+        end
+      end
+    end
+
+    private
+
+    ##
+    # Register services with the loader
+    #
+    # :nocov:
+    def register_services(svcs)
+      self.services = Array(svcs).concat(Gruf.services).compact.uniq
+    end
+    # :nocov:
+
+  end
+end

--- a/spec/demo_app_root/fake_demo_service.rb
+++ b/spec/demo_app_root/fake_demo_service.rb
@@ -1,0 +1,3 @@
+class FakeDemoService
+  include Gruf::Service
+end

--- a/spec/demo_app_root/non_sevice.rb
+++ b/spec/demo_app_root/non_sevice.rb
@@ -1,0 +1,3 @@
+module NonService
+  raise 'Only Gruf Services should be explicitly required by Gruf!'
+end

--- a/spec/gruf/server_spec.rb
+++ b/spec/gruf/server_spec.rb
@@ -21,60 +21,22 @@ describe Gruf::Server do
   let(:gruf_server) { described_class.new(services: services) }
   subject { gruf_server }
 
-  describe '.load_services' do
-    context 'when passed no services' do
-      context 'but some are configured in initializer' do
-        before do
-          Gruf.configure do |c|
-            c.services << ThingService
-            c.services << ThingService
-          end
-        end
-
-        it 'should return all services loaded in configuration uniquely' do
-          expect(subject.services).to eq [ThingService]
-        end
-      end
-
-      context 'and none are configured in initializer' do
-        before do
-          Gruf.configure do |c|
-            c.services = []
-          end
-        end
-
-        it 'should return an empty array' do
-          expect(subject.services).to eq []
-        end
-      end
-    end
-
-    context 'when passed a service' do
+  describe '.new' do
+    describe 'services' do
       let(:services) { [ThingService] }
+      let(:service_loader) { instance_double(Gruf::ServiceLoader, require_services: nil) }
 
-      context 'and some are configured in an initializer' do
-        before do
-          Gruf.configure do |c|
-            c.services << ThingService
-            c.services << ThingService
-          end
-        end
-
-        it 'should return all services loaded in configuration uniquely' do
-          expect(subject.services).to eq [ThingService]
+      before do
+        # Ensure the ServiceLoader can be initialized with the provided arguments while returning a test double.
+        allow(Gruf::ServiceLoader).to receive(:new).and_wrap_original do |m, *args|
+          m.call(*args)
+          service_loader
         end
       end
 
-      context 'and none are configured in initializer' do
-        before do
-          Gruf.configure do |c|
-            c.services = []
-          end
-        end
-
-        it 'should return all services loaded in configuration uniquely' do
-          expect(subject.services).to eq services
-        end
+      it 'registers services on initialization' do
+        subject
+        expect(service_loader).to have_received(:require_services)
       end
     end
   end

--- a/spec/gruf/service_loader_spec.rb
+++ b/spec/gruf/service_loader_spec.rb
@@ -1,0 +1,125 @@
+# coding: utf-8
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+describe Gruf::ServiceLoader do
+  describe '.new' do
+    context 'when passed no services' do
+      subject(:loader) { described_class.new }
+
+      context 'but some are configured in initializer' do
+        before do
+          Gruf.configure do |c|
+            c.services << ThingService
+            c.services << ThingService
+          end
+        end
+
+        it 'should return all services loaded in configuration uniquely' do
+          expect(loader.services).to eq [ThingService]
+        end
+      end
+
+      context 'and none are configured in initializer' do
+        before do
+          Gruf.configure do |c|
+            c.services = []
+          end
+        end
+
+        it 'should return an empty array' do
+          expect(loader.services).to eq []
+        end
+      end
+    end
+
+    context 'when passed a service' do
+      let(:services) { [ThingService] }
+      subject(:loader) { described_class.new(services: services) }
+
+      context 'and some are configured in an initializer' do
+        before do
+          Gruf.configure do |c|
+            c.services << ThingService
+            c.services << ThingService
+          end
+        end
+
+        it 'should return all services loaded in configuration uniquely' do
+          expect(loader.services).to eq [ThingService]
+        end
+      end
+
+      context 'and none are configured in initializer' do
+        before do
+          Gruf.configure do |c|
+            c.services = []
+          end
+        end
+
+        it 'should return all services loaded in configuration uniquely' do
+          expect(loader.services).to eq services
+        end
+      end
+    end
+  end
+
+  describe '#require_services' do
+    let(:fake_app_root) { File.join(File.expand_path('../../', __FILE__), 'demo_app_root') }
+    let(:loader) { described_class.new(load_path: fake_app_root) }
+    subject(:require_services) { loader.require_services }
+
+    before do
+      Gruf.configure do |c|
+        c.servers_path = fake_app_root
+      end
+    end
+
+    context 'when files include the Gruf::Service module' do
+      let(:service_file) { Pathname.new(fake_app_root).join('fake_demo_service.rb') }
+
+      before do
+        allow(loader).to receive(:require)
+        allow(loader.logger).to receive(:info)
+      end
+
+      it 'the file is required' do
+        require_services
+        expect(loader).to have_received(:require).with(service_file.to_s)
+      end
+
+      it 'logs the files was required' do
+        expect_log_message = "- Loading gRPC service file: #{service_file}"
+        require_services
+        expect(loader.logger).to have_received(:info).with(expect_log_message)
+      end
+    end
+
+    context 'when files do not include the Gruf::Service module' do
+      let(:non_required_file) { Pathname.new(fake_app_root).join('non_service.rb') }
+
+      before do
+        allow(loader).to receive(:require)
+      end
+
+      it 'is not required' do
+        require_services
+        expect(loader).not_to have_received(:require).with(non_required_file.to_s)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What? Why?
Gruf explicitly requires files in the `servers_path` directory. This doesn't play nicely with autoloading in Rails projects when concerns live in the `servers_path` directory as they can only be required once.

This PR:
* Extracts the services loading functionality into `Gruf::ServiceLoader`
* Updates the loading logic to identify  and only require services that include the Gruf::Service mixin

## How was it tested?
`rspec`. Note: I copied the existing service loading specs from `server_spec.rb` to help make sure no regressions are introduced in the refactor.
