### PR TITLE
Fix issue with AR connection pooling in Rails 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+### 2.0.1
+
+- Handle ActiveRecord connection management more gracefully (Fixes #30)
+
 ### 2.0.0
 
 Gruf 2.0 is a major shift from Gruf 1.0. See [UPGRADING.md](UPGRADING.md) for details.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ username and password pairs (or password-only credentials).
 ```ruby
 Gruf.configure do |c|
   c.interceptors.use(
-    Gruf::Instrumentation::Authentication::Basic,
+    Gruf::Interceptors::Authentication::Basic,
     credentials: [{
       username: 'my-username-here',
       password: 'my-password-here',    

--- a/spec/gruf/interceptors/active_record/connection_reset_spec.rb
+++ b/spec/gruf/interceptors/active_record/connection_reset_spec.rb
@@ -16,12 +16,6 @@
 #
 require 'spec_helper'
 
-module ActiveRecord
-  class Base
-    def self.clear_active_connections!; end
-  end
-end
-
 describe Gruf::Interceptors::ActiveRecord::ConnectionReset do
   let(:request) { build :controller_request }
   let(:errors) { build :error }
@@ -35,7 +29,8 @@ describe Gruf::Interceptors::ActiveRecord::ConnectionReset do
     end
 
     it 'should try to clear any active connections' do
-      expect(::ActiveRecord::Base).to receive(:clear_active_connections!)
+      expect(::ActiveRecord::Base).to receive(:establish_connection).and_call_original
+      expect(::ActiveRecord::Base).to receive(:clear_active_connections!).and_call_original
       subject
     end
   end
@@ -46,6 +41,7 @@ describe Gruf::Interceptors::ActiveRecord::ConnectionReset do
     end
 
     it 'should not try to clear any active connections' do
+      expect(::ActiveRecord::Base).to_not receive(:establish_connection)
       expect(::ActiveRecord::Base).to_not receive(:clear_active_connections!)
       subject
     end

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -14,35 +13,32 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-module Gruf
-  module Interceptors
-    module ActiveRecord
-      ##
-      # Resets the ActiveRecord connection to maintain accurate connected state in the thread pool
-      #
-      class ConnectionReset < ::Gruf::Interceptors::ServerInterceptor
-        ##
-        # Reset any ActiveRecord connections after a gRPC service is called. Because of the way gRPC manages its
-        # connection pool, we need to ensure that this is done to properly
-        #
-        def call
-          if enabled? && !::ActiveRecord::Base.connection.active?
-            ::ActiveRecord::Base.establish_connection
-          end
-          yield
-        ensure
-          ::ActiveRecord::Base.clear_active_connections! if enabled?
-        end
+module ActiveRecord
+  class Base
+    def self.connection
+      ActiveRecord::Connection.new
+    end
 
-        private
+    def self.establish_connection
+      true
+    end
 
-        ##
-        # @return [Boolean] If AR is loaded, we can enable this hook safely
-        #
-        def enabled?
-          defined?(::ActiveRecord::Base)
-        end
-      end
+    def self.clear_active_connections!
+      true
+    end
+
+    def self.connected?
+      true
+    end
+  end
+
+  class Connection
+    def disconnect!
+      true
+    end
+
+    def active?
+      false
     end
   end
 end


### PR DESCRIPTION
## What? Why?

Fixes #30 - which is caused by `::ActiveRecord::Base.clear_active_connections!` not properly clearing connections during the hook. This PR ensures that the `clear_active_connections!` call is made, and also properly tries to re-establish the connection on each new call.

Also fixes #29 in README.

----

@pedelman 