### PR TITLE
Fix LoadError for non-rails applications

### DIFF
--- a/bin/gruf
+++ b/bin/gruf
@@ -17,7 +17,11 @@
 #
 require 'rubygems'
 require 'bundler/setup'
-require 'rails' rescue nil
+begin
+  require 'rails'
+rescue LoadError
+  nil
+end
 load 'config/environment.rb' if defined?(Rails)
 require 'gruf'
 


### PR DESCRIPTION
## What? Why?

Can not use gruf in a non-rails application.
https://github.com/bigcommerce/gruf/issues/34

## How was it tested?

Tested locally in irb.

```bash
xinchen.shen@xinchen ~/SandBox/gruf (fix-LoadError) $ ./bin/console
>> require 'rails' rescue nil
LoadError: cannot load such file -- rails
	from (irb):1:in `require'
	from (irb):1
	from ./bin/console:26:in `<main>'
>> begin
?>   require 'rails'
>> rescue LoadError
>>   nil
>> end
=> nil
```