### PR TITLE
Interceptor registry improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Add ability to list, clear, insert before, insert after, and remove to a server's interceptor
+registry
+- Ensure interceptors and services cannot be adjusted on the server after it starts to 
+prevent threading issues
 - [#36], [#37] Adds `response_class`, `request_class`, and `service` accessors to controller request
- 
+
 ### 2.0.3
 
 - Fix regression [#35] where gruf was not able to be loaded outside of a Rails application

--- a/README.md
+++ b/README.md
@@ -239,6 +239,10 @@ Gruf.configure do |c|
 end
 ```
 
+By default, the ActiveRecord Connection Reset interceptor and Output Metadata Timing interceptor
+are loaded into gruf unless explicitly told not to via the `use_default_interceptors` configuration
+parameter.
+
 ## Instrumentation
 
 gruf comes out of the box with a couple of instrumentation interceptors packed in: 

--- a/spec/gruf/interceptors/registry_spec.rb
+++ b/spec/gruf/interceptors/registry_spec.rb
@@ -97,6 +97,32 @@ describe Gruf::Interceptors::Registry do
     end
   end
 
+  describe '.remove' do
+    subject { registry.remove(interceptor_class) }
+
+    before do
+      registry.use(interceptor_class2)
+      registry.use(interceptor_class3)
+    end
+
+    context 'if the interceptor is in the registry' do
+      before do
+        registry.use(interceptor_class)
+      end
+
+      it 'should remove the interceptor from the registry' do
+        expect { subject }.not_to raise_error
+        expect(registry.count).to eq 2
+      end
+    end
+
+    context 'if the interceptor is not in the registry' do
+      it 'should raise an InterceptorNotFoundError exception' do
+        expect { subject }.to raise_error(described_class::InterceptorNotFoundError)
+      end
+    end
+  end
+
   describe '.clear' do
     subject { registry.clear }
 

--- a/spec/gruf/server_spec.rb
+++ b/spec/gruf/server_spec.rb
@@ -67,6 +67,16 @@ describe Gruf::Server do
         expect { subject }.to_not(change { gruf_server.instance_variable_get('@services').count })
       end
     end
+
+    context 'if the server is already started' do
+      before do
+        gruf_server.instance_variable_set(:@started, true)
+      end
+
+      it 'should raise a ServerAlreadyStartedError exception' do
+        expect { subject }.to raise_error(Gruf::Server::ServerAlreadyStartedError)
+      end
+    end
   end
 
   describe '.add_interceptor' do
@@ -84,6 +94,151 @@ describe Gruf::Server do
       i = is.first
       expect(i).to be_a(interceptor_class)
       expect(i.options).to eq options
+    end
+
+    context 'if the server is already started' do
+      before do
+        gruf_server.instance_variable_set(:@started, true)
+      end
+
+      it 'should raise a ServerAlreadyStartedError exception' do
+        expect { subject }.to raise_error(Gruf::Server::ServerAlreadyStartedError)
+      end
+    end
+  end
+
+  describe '.list_interceptors' do
+    let(:interceptor) { TestServerInterceptor }
+    subject { gruf_server.list_interceptors }
+
+    before do
+      Gruf.interceptors.clear
+      gruf_server.add_interceptor(interceptor)
+    end
+
+    it 'should return the current list of interceptors' do
+      expect(subject).to eq [interceptor]
+    end
+  end
+
+  describe '.insert_interceptor_before' do
+    let(:interceptor) { TestServerInterceptor }
+    let(:interceptor2) { TestServerInterceptor2 }
+
+    subject { gruf_server.insert_interceptor_before(interceptor, interceptor2) }
+
+    before do
+      Gruf.interceptors.clear
+      gruf_server.add_interceptor(interceptor)
+    end
+
+    it 'should add the new interceptor before the targeted one' do
+      expect { subject }.to_not raise_error
+      expect(gruf_server.list_interceptors).to eq [interceptor2, interceptor]
+    end
+
+    context 'if the server is already started' do
+      before do
+        gruf_server.instance_variable_set(:@started, true)
+      end
+
+      it 'should raise a ServerAlreadyStartedError exception' do
+        expect { subject }.to raise_error(Gruf::Server::ServerAlreadyStartedError)
+      end
+    end
+  end
+
+  describe '.insert_interceptor_after' do
+    let(:interceptor) { TestServerInterceptor }
+    let(:interceptor2) { TestServerInterceptor2 }
+    let(:interceptor3) { TestServerInterceptor3 }
+
+    subject { gruf_server.insert_interceptor_after(interceptor, interceptor3) }
+
+    before do
+      Gruf.interceptors.clear
+      gruf_server.add_interceptor(interceptor)
+      gruf_server.add_interceptor(interceptor2)
+    end
+
+    it 'should add the new interceptor after the targeted one' do
+      expect { subject }.to_not raise_error
+      expect(gruf_server.list_interceptors).to eq [interceptor, interceptor3, interceptor2]
+    end
+
+    context 'if the server is already started' do
+      before do
+        gruf_server.instance_variable_set(:@started, true)
+      end
+
+      it 'should raise a ServerAlreadyStartedError exception' do
+        expect { subject }.to raise_error(Gruf::Server::ServerAlreadyStartedError)
+      end
+    end
+  end
+
+  describe '.remove_interceptor' do
+    let(:interceptor) { TestServerInterceptor }
+    let(:interceptor2) { TestServerInterceptor2 }
+    let(:interceptor3) { TestServerInterceptor3 }
+    subject { gruf_server.remove_interceptor(interceptor) }
+
+    before do
+      Gruf.interceptors.clear
+      gruf_server.add_interceptor(interceptor2)
+      gruf_server.add_interceptor(interceptor3)
+    end
+
+    context 'when the interceptor is in the registry' do
+      before do
+        gruf_server.add_interceptor(interceptor)
+      end
+
+      it 'should remove the interceptor from the registry' do
+        expect { subject }.to_not raise_error
+        expect(gruf_server.list_interceptors.count).to eq 2
+      end
+    end
+
+    context 'when the interceptor is not in the registry' do
+      it 'should raise a InterceptorNotFoundError exception' do
+        expect { subject }.to raise_error(Gruf::Interceptors::Registry::InterceptorNotFoundError)
+      end
+    end
+
+    context 'if the server is already started' do
+      before do
+        gruf_server.instance_variable_set(:@started, true)
+      end
+
+      it 'should raise a ServerAlreadyStartedError exception' do
+        expect { subject }.to raise_error(Gruf::Server::ServerAlreadyStartedError)
+      end
+    end
+  end
+
+  describe '.clear_interceptors' do
+    let(:interceptor) { TestServerInterceptor }
+    subject { gruf_server.clear_interceptors }
+
+    before do
+      Gruf.interceptors.clear
+      gruf_server.add_interceptor(interceptor)
+    end
+
+    it 'should clear all interceptors from the registry' do
+      expect { subject }.to_not raise_error
+      expect(gruf_server.list_interceptors).to eq []
+    end
+
+    context 'if the server is already started' do
+      before do
+        gruf_server.instance_variable_set(:@started, true)
+      end
+
+      it 'should raise a ServerAlreadyStartedError exception' do
+        expect { subject }.to raise_error(Gruf::Server::ServerAlreadyStartedError)
+      end
     end
   end
 end


### PR DESCRIPTION
## What? Why?

* Add ability to list, clear, insert before, and insert after to a server's interceptor
registry
* Ensure interceptors and services cannot be adjusted on the server after it starts to 
prevent threading issues and other unwanted behavior

## How was it tested?

rspec, `spec/demo_server`, and other testing.
