### PR TITLE
ignore_methods option for RequestLogging interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ It comes with a few more options as well:
 | log_parameters | If set to true, will log parameters in the response | `false` |
 | blacklist | An array of parameter key names to redact from logging, in path.to.key format | `[]` |
 | redacted_string | The string to use for redacted parameters. | `REDACTED` |
+| ignore_methods | An array of method names to ignore from logging. E.g. `['namespace.health.check']` | `[]` |
 
 It's important to maintain a safe blacklist should you decide to log parameters; gruf does no
 parameter sanitization on its own. We also recommend blacklisting parameters that may contain

--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
@@ -43,6 +43,8 @@ module Gruf
           # @return [String]
           #
           def call
+            return yield if options.fetch(:ignore_methods, []).include?(request.method_name)
+
             result = Gruf::Interceptors::Timer.time do
               yield
             end

--- a/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
@@ -39,6 +39,15 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
         expect(Gruf.logger).to receive(:info).once
         subject
       end
+
+      context 'with ignore_methods set' do
+        let(:options) { { ignore_methods: %w[rpc.thing_service.get_thing] } }
+
+        it 'shouldn\'t log the call' do
+          expect(Gruf.logger).not_to receive(:info)
+          subject
+        end
+      end
     end
 
     context 'and the request was a failure' do


### PR DESCRIPTION
## What? Why?

When you use e.g. healthchecks logs can get really crouded with those.

## How was it tested?

With spec