### PR TITLE
add `--pid-file` `--daemon` options when start gruf 

### DIFF
--- a/bin/gruf
+++ b/bin/gruf
@@ -26,9 +26,8 @@ load 'config/environment.rb' if defined?(Rails)
 require 'gruf'
 
 begin
-  server = Gruf::Server.new(Gruf.server_options)
-  Gruf.services.each { |s| server.add_service(s) }
-  server.start!
+  cli = Gruf::CLI.instance
+  cli.run
 rescue => e
   msg = "FATAL ERROR: #{e.message} #{e.backtrace.join("\n")}"
   if Gruf.logger

--- a/lib/gruf.rb
+++ b/lib/gruf.rb
@@ -31,6 +31,7 @@ require_relative 'gruf/response'
 require_relative 'gruf/error'
 require_relative 'gruf/client'
 require_relative 'gruf/server'
+require_relative 'gruf/cli'
 
 ##
 # Initializes configuration of gruf core module

--- a/lib/gruf/cli.rb
+++ b/lib/gruf/cli.rb
@@ -40,7 +40,7 @@ module Gruf
         files_to_reopen << file unless file.closed?
       end
 
-      ::Process.daemon(true, true)
+      ::Process.daemon
 
       files_to_reopen.each do |file|
         begin

--- a/lib/gruf/cli.rb
+++ b/lib/gruf/cli.rb
@@ -7,7 +7,7 @@ module Gruf
   class CLI
     include Singleton
 
-    attr_accessor :options
+    attr_reader :options
 
     def run(args=ARGV)
       @options = parse_options(args)

--- a/lib/gruf/cli.rb
+++ b/lib/gruf/cli.rb
@@ -23,9 +23,10 @@ module Gruf
         server = Gruf::Server.new(Gruf.server_options)
         Gruf.services.each { |s| server.add_service(s) }
         server.start!
+        exit 0
       rescue Interrupt
         Gruf.logger.info 'Shutting down'
-        exit(0)
+        exit 0
       end
     end
 

--- a/lib/gruf/cli.rb
+++ b/lib/gruf/cli.rb
@@ -1,0 +1,90 @@
+$stdout.sync = true
+
+require 'singleton'
+require 'optparse'
+
+module Gruf
+  class CLI
+    include Singleton
+
+    attr_accessor :options
+
+    def run(args=ARGV)
+      @options = parse_options(args)
+
+      daemonize
+      write_pid
+
+      if !options[:daemon]
+        Gruf.logger.info 'Starting processing, hit Ctrl-C to stop'
+      end
+
+      begin
+        server = Gruf::Server.new(Gruf.server_options)
+        Gruf.services.each { |s| server.add_service(s) }
+        server.start!
+      rescue Interrupt
+        Gruf.logger.info 'Shutting down'
+        exit(0)
+      end
+    end
+
+    private
+
+    def daemonize
+      return if !options[:daemon]
+
+      files_to_reopen = []
+      ObjectSpace.each_object(File) do |file|
+        files_to_reopen << file unless file.closed?
+      end
+
+      ::Process.daemon(true, true)
+
+      files_to_reopen.each do |file|
+        begin
+          file.reopen file.path, "a+"
+          file.sync = true
+        rescue ::Exception
+        end
+      end
+
+      Gruf.logger.reopen
+      $stdin.reopen('/dev/null')
+    end
+
+    def parse_options(argv)
+      opts = {}
+
+      @parser = OptionParser.new do |o|
+        o.banner = "Usage: bundle exec gruf [options]"
+
+        o.on '-d', '--daemon', "Daemonize process" do |arg|
+          opts[:daemon] = arg
+        end
+
+        o.on '-P', '--pidfile PATH', "path to pidfile" do |arg|
+          opts[:pidfile] = arg
+        end
+
+        o.on '-V', '--version', "Print version and exit" do |arg|
+          puts "Gruf #{Gruf::VERSION}"
+          exit(0)
+        end
+      end
+
+      @parser.parse!(argv)
+      opts
+    end
+
+    def write_pid
+      if path = options[:pidfile]
+        pidfile = File.expand_path(path)
+        File.open(pidfile, 'w') do |f|
+          f.puts ::Process.pid
+        end
+      end
+    end
+
+  end
+end

--- a/spec/gruf/cli_spec.rb
+++ b/spec/gruf/cli_spec.rb
@@ -1,0 +1,30 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+describe Gruf::CLI do
+  let(:cli) { described_class.instance }
+
+  describe '.parse_options' do
+    subject { cli }
+
+    it 'should parse the right options' do
+      opts = subject.send(:parse_options, ["-d", "-P", "tmp/gruf.pid"])
+      expect(!!opts[:daemon]).to eq true
+      expect(opts[:pidfile]).to eq "tmp/gruf.pid"
+    end
+  end
+end


### PR DESCRIPTION
## What? Why?

I write a cli.rb, so we can use `bundle exec grpc -d  -P [YOUR_PID_FILE]` to make the gruf server daemonized.


## How was it tested?

`rspec`