### PR TITLE
fix(platform): GRUF-49 Interpret InvalidArguments as info, not errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### 2.4.0
 
-- Added three log levels: warn, info, error, mapped to explicit sets of GRPC error codes [#49]
-- Override log levels supplying info_level_codes, warn_level_codes, and error_level_codes in options of Interceptor constructor
-- Non-explicitly mapped error codes will be treated as :error level
+- Added a hash of error log levels to Interceptor class, mapping error code to level of logging to use.
+- To override the level of logging per error response, provide a map of codes to log level in options, key :log_levels. 
+- Default is :error log level.
 
 ### 2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+### 2.4.0
+
+- Added three log levels: warn, info, error, mapped to explicit sets of GRPC error codes [#49]
+- Override log levels supplying info_level_codes, warn_level_codes, and error_level_codes in options of Interceptor constructor
+- Non-explicitly mapped error codes will be treated as :error level
+
 ### 2.3.0
 
 - Add Gruf::Interceptors::ClientInterceptor for intercepting outbound client calls

--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
@@ -14,7 +14,6 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 require 'socket'
-require 'pry'
 require_relative 'formatters/base'
 require_relative 'formatters/logstash'
 require_relative 'formatters/plain'

--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
@@ -49,7 +49,10 @@ module Gruf
               yield
             end
 
-            if result.successful?
+            if result.message.is_a?(GRPC::InvalidArgument)
+              type = options.fetch(:success_log_level, :info).to_sym
+              status_name = 'GRPC::InvalidArgument'
+            elsif result.successful?
               type = options.fetch(:success_log_level, :info).to_sym
               status_name = 'GRPC::Ok'
             else

--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
@@ -41,7 +41,7 @@ module Gruf
           LOG_LEVEL_MAPS = {
             info_level_codes: [GRPC::Ok, GRPC::InvalidArgument, GRPC::NotFound, GRPC::AlreadyExists, GRPC::OutOfRange],
             warn_level_codes: [GRPC::Unauthenticated, GRPC::PermissionDenied],
-            error_level_codes: [GRPC::Unknown, GRPC::Internal, GRPC::DataLoss, GRPC::FailedPrecondition, GRPC::Unavailable, GRPC::DeadlineExceeded, GRPC::Cancelled],
+            error_level_codes: [GRPC::Unknown, GRPC::Internal, GRPC::DataLoss, GRPC::FailedPrecondition, GRPC::Unavailable, GRPC::DeadlineExceeded, GRPC::Cancelled]
           }.freeze
 
           ###

--- a/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
@@ -34,6 +34,21 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
   describe '.call' do
     subject { call }
 
+    context 'and the request was an invalid argument' do
+      let(:call) do
+        interceptor.call do
+          raise GRPC::InvalidArgument, 'invalid argument'
+        end
+      end
+
+      it 'should log the call properly as an INFO' do
+        expect(Gruf.logger).to receive(:info).once
+        expect { subject }.to raise_error(GRPC::InvalidArgument) do |e|
+          expect(e.details).to eq 'invalid argument'
+        end
+      end
+    end
+
     context 'and the request was successful' do
       it 'should log the call properly as an INFO' do
         expect(Gruf.logger).to receive(:info).once

--- a/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
@@ -50,7 +50,7 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
     end
 
     context 'and the request was an invalid argument that was overwritten' do
-      let(:options) { { warn_level_codes: [GRPC::InvalidArgument], info_level_codes: [], error_level_codes: []} }
+      let(:options) { { log_levels: { 'GRPC::InvalidArgument' => :warn } } }
 
       let(:call) do
         interceptor.call do


### PR DESCRIPTION
## What? Why?
Fixes issue #49, returns as INFO for InvalidArguments

## How was it tested?
See spec. Assume we return as INFO if we raise InvalidArgument exception.
