### PR TITLE
Add logging for unhandled exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 - Added a hash of error log levels to Interceptor class, mapping error code to level of logging to use.
 - To override the level of logging per error response, provide a map of codes to log level in options, key :log_levels. 
 - Default is :error log level.
+- Add error logging of unhandled exceptions that occur during a call.
 
 ### 2.3.0
 

--- a/lib/gruf/controllers/base.rb
+++ b/lib/gruf/controllers/base.rb
@@ -73,6 +73,7 @@ module Gruf
       rescue GRPC::BadStatus
         raise # passthrough
       rescue StandardError => e
+        Gruf.logger.error "Unhandled #{e.class.name}: #{e.message} #{e.backtrace.join("\n")}"
         set_debug_info(e.message, e.backtrace) if Gruf.backtrace_on_error
         error_message = Gruf.use_exception_message ? e.message : Gruf.internal_error_message
         fail!(:internal, :unknown, error_message)


### PR DESCRIPTION
## What? Why?
* We have good error handling in the request logging interceptor, but if an unhandled exception occurs, we don't currently log it.
* This adds logging with extended debug information, but preserves the behavior of what we send back to the client.

## How was it tested?
* Added a `fail` in one of my rpc handlers, saw the log message using the configured logger.
