### PR TITLE
Set exception message for Gruf::Client::Error

### DIFF
--- a/lib/gruf/client.rb
+++ b/lib/gruf/client.rb
@@ -49,6 +49,23 @@ module Gruf
       #
       def initialize(error)
         @error = error
+        super(error_message)
+      end
+
+      private
+
+      ##
+      # Format the exception message
+      #
+      # @return [String] A formatted exception message
+      #
+      def error_message
+        if @error.is_a?(Hash) && @error.key?('code') && @error.key?('message')
+          return "GRPC #{@error['code'].to_s.humanize.capitalize}: #{@error['message']}"
+        end
+
+        # Default exception message is the class name
+        self.class.to_s
       end
     end
 

--- a/spec/gruf/client_spec.rb
+++ b/spec/gruf/client_spec.rb
@@ -108,6 +108,7 @@ describe Gruf::Client do
             expect(e.error['code']).to eq error_code.to_s
             expect(e.error['app_code']).to eq app_error_code.to_s
             expect(e.error['message']).to eq error_message
+            expect(e.message).to eq("GRPC Not found: #{error_message}")
           end
         end
       end
@@ -181,6 +182,32 @@ describe Gruf::Client::Error do
   context '.initialize' do
     it 'should set the error object on the class' do
       expect(subject.error).to eq err_obj
+    end
+
+    it "set the exception's message to #{described_class.to_s}" do
+      expect(subject.message).to eq(described_class.to_s)
+    end
+
+    context 'error obj a Hash' do
+      context "without keys 'code' and 'message'" do
+        let(:err_obj) { { 'some' => 'hash' } }
+
+        it "set the exception's message to #{described_class.to_s}" do
+          expect(subject.error).to eq err_obj
+          expect(subject.message).to eq(described_class.to_s)
+        end
+      end
+
+      context "having keys 'code' and 'message'" do
+        let(:error_message) { 'An error occurred' }
+        let(:error_code) { :not_found }
+        let(:err_obj) { { 'code' => error_code, 'message' => error_message } }
+
+        it 'formats the exception message' do
+          expect(subject.error).to eq err_obj
+          expect(subject.message).to eq("GRPC Not found: #{error_message}")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## What?

This PR sets the `message` attribute on instances of `Gruf::Client::Error` (when possible).

Before:

```rb
begin
  raise Gruf::Client::Error, { 'code' => 'internal', 'message' => 'An error occurred' }
rescue => e
  puts e.message
end

=> Gruf::Client::Error
```

After:
```rb
begin
  raise Gruf::Client::Error, { 'code' => 'internal', 'message' => 'An error occurred' }
rescue => e
  puts e.message
end

=> 'GRPC Internal: An error occurred'
```


## Why?

Error services (such as [Sentry](https://sentry.io/)) use the exception's message to more effectively group exceptions. If the message is always `Gruf::Client::Error`, different exceptions are improperly grouped together under the same event.

## How was it tested?

The specs + using a monkey patch on a service

