### PR TITLE
PEN-925: Handle overflow of metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
   from StandardError. [#59]
 - Removed `Thread.abort\_on\_exception = true`. Exceptions should be handled by gruf or the application,
   and should not cause the server process to crash. [#59]
+- Added guard for size of trailing metadata attached to grpc call. The default max for http2 trailing metadata
+  in the gRPC C library is 8kb. If we go over that limit (either through custom metadata attached to the
+  error by the application, or via the error payload encoded by the error serializer), the gRPC library
+  will throw RESOURCE\_EXHAUSTED. Gruf now detects this case, and attempts to prevent it by logging the
+  original error and substituting it with an internal error indicating that the metadata was too large. [#60]
+- Truncate stack trace in error payload to help avoid overflowing the trailing metadata. Added backtrace\_limit
+  configuration parameter, which defaults to 10.[#60]
 
 ### 2.4.1
 
@@ -16,8 +23,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### 2.4.0
 
-- Added a hash of error log levels to RequestLogging interceptor, mapping error code to level of logging to use. To 
-override the level of logging per error response, provide a map of codes to log level in options, key :log_levels. 
+- Added a hash of error log levels to RequestLogging interceptor, mapping error code to level of logging to use. To
+override the level of logging per error response, provide a map of codes to log level in options, key :log_levels.
 The default is :error log level.
 
 ### 2.3.0
@@ -32,7 +39,7 @@ The default is :error log level.
 
 ### 2.2.1
 
-- Now changes proc title once server is ready to process incoming requests [#44] 
+- Now changes proc title once server is ready to process incoming requests [#44]
 - Gruf now requires gRPC 1.10.x+ due to various fixes and improvements in the gRPC core libraries
 
 ### 2.2.0
@@ -41,13 +48,13 @@ The default is :error log level.
 
 ### 2.1.1
 
-- Add ability to pass in client stub options into Gruf::Client 
+- Add ability to pass in client stub options into Gruf::Client
 
 ### 2.1.0
 
 - Add ability to list, clear, insert before, insert after, and remove to a server's interceptor
 registry
-- Ensure interceptors and services cannot be adjusted on the server after it starts to 
+- Ensure interceptors and services cannot be adjusted on the server after it starts to
 prevent threading issues
 - [#36], [#37] Adds `response_class`, `request_class`, and `service` accessors to controller request
 
@@ -110,22 +117,22 @@ Gruf 2.0 is a major shift from Gruf 1.0. See [UPGRADING.md](UPGRADING.md) for de
 - Instrumentation hooks now execute similarly to outer_around hooks; they can
   now instrument failures
 - Instrumentation hooks now pass a `RequestContext` object that contains information
-  about the incoming request, instead of relying on instance variables 
+  about the incoming request, instead of relying on instance variables
 - StatsD hook now sends success/failure metrics for endpoints
 - Add ability to turn off sending exception message on uncaught exception.
 - Add configuration to set the error message when an uncaught exception is
   handled by gruf.
-- Add a request logging hook for Rails-style request logging, with optional 
-  parameter logging, blacklists, and formatter support 
+- Add a request logging hook for Rails-style request logging, with optional
+  parameter logging, blacklists, and formatter support
 - Optimizations around Symbol casting within service calls
 
 ### 1.1.0
 
-- Add the ability for call options to the client, which enables deadline setting 
+- Add the ability for call options to the client, which enables deadline setting
 
 ### 1.0.0
 
-- Bump gRPC to 1.4 
+- Bump gRPC to 1.4
 
 ### 0.14.2
 
@@ -154,7 +161,7 @@ Gruf 2.0 is a major shift from Gruf 1.0. See [UPGRADING.md](UPGRADING.md) for de
 ### 0.12.0
 
 - Add ability to run multiple around hooks
-- Fix bug with error handling that caused error messages to repeat across streams 
+- Fix bug with error handling that caused error messages to repeat across streams
 
 ### 0.11.5
 

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -36,6 +36,7 @@ module Gruf
       append_server_errors_to_trailing_metadata: true,
       use_default_interceptors: true,
       backtrace_on_error: false,
+      backtrace_limit: 10,
       use_exception_message: true,
       internal_error_message: 'Internal Server Error',
       event_listener_proc: nil,

--- a/lib/gruf/errors/debug_info.rb
+++ b/lib/gruf/errors/debug_info.rb
@@ -30,7 +30,12 @@ module Gruf
       #
       def initialize(detail, stack_trace = [])
         @detail = detail
-        @stack_trace = stack_trace.is_a?(String) ? stack_trace.split("\n") : stack_trace
+        @stack_trace = (stack_trace.is_a?(String) ? stack_trace.split("\n") : stack_trace)
+
+        # Limit the size of the stack trace to reduce risk of overflowing metadata
+        stack_trace_limit = Gruf.backtrace_limit.to_i
+        stack_trace_limit = 10 if stack_trace_limit < 0
+        @stack_trace = @stack_trace[0..stack_trace_limit] if stack_trace_limit > 0
       end
 
       ##

--- a/spec/gruf/error_spec.rb
+++ b/spec/gruf/error_spec.rb
@@ -60,6 +60,17 @@ describe Gruf::Error do
           expect(subject).to be_a(described_class)
         end
       end
+
+      context 'with a very large error message' do
+        let(:message) { SecureRandom.hex(10000) }
+        it 'should log the original error and replace the outgoing error with a new one' do
+          expect(Gruf.logger).to receive(:warn)
+          expect(subject).to be_a(described_class)
+          expect(subject.code).to eq(:internal)
+          expect(subject.app_code).to eq(described_class::METADATA_SIZE_EXCEEDED_CODE)
+          expect(subject.message).to eq(described_class::METADATA_SIZE_EXCEEDED_MSG)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## What? Why?
* The gRPC C library has a default max size on trailing metadata of 8kb. Update the Error class to consider this when attaching metadata to the gRPC call. If the overall size of the metadata, including metadata added by the application, and the error payload added by the error serializer, is in danger of exceeding that limit, log the error and replace the wire error with a new one indicating metadata overflow.
* Truncate stack trace attached to error payload to ten lines to reduce risk of overflow.

## How was it tested?
* gRPC server app with an endpoint that calls `fail!(:internal, :unknown, SecureRandom.hex(9000))`
* Call it with a client that logs the response

Server side:
```
I, [2018-08-16T18:48:43.173244 #2735]  INFO -- : deadline is 1969-12-31 15:59:59 -0800; (now=2018-08-16 18:48:43 -0700)
I, [2018-08-16T18:48:43.173316 #2735]  INFO -- : schedule another job
W, [2018-08-16T18:48:43.392624 #2735]  WARN -- : metadata_size_exceeded: Metadata too long, risks exceeding http2 trailing metadata limit. Original error: {:code=>:internal, :app_code=>:unknown, :message=>"<big long random string>", :field_errors=>[], :debug_info=>{}}
D, [2018-08-16T18:48:43.394784 #2735] DEBUG -- : app err:#<GRPC::ActiveCall:0x007fb3c70c8fa0>, status:13:Metadata too long, risks exceeding http2 trailing metadata limit.
D, [2018-08-16T18:48:43.394822 #2735] DEBUG -- : Sending status  13:Metadata too long, risks exceeding http2 trailing metadata limit.
```

Client side:
```
D, [2018-08-16T18:48:41.600250 #2740] DEBUG -- : Failing with status #<struct Struct::Status code=13, details="Metadata too long, risks exceeding http2 trailing metadata limit.", metadata={"error-internal-bin"=>"\n\x16metadata_size_exceeded\x12AMetadata too long, risks exceeding http2 trailing metadata limit."}>
```