### PR TITLE
Add SynchronizedClient to mitigate thundering herds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 Changelog for the gruf gem. This includes internal history before the gem was made.
 
 ### Pending release
-
 - Client exceptions raised now contain mapped subclasses, such as `Gruf::Client::Errors::InvalidArgument`
 - Client exceptions will also now catch StandardError and GRPC::Core errors, and handle them as Internal errors
+- Added SynchronizedClient which prevents multiple calls to the same endpoint with the same params at
+  a given time. This is useful for mitigating thundering herds. To skip this behavior for certain endpoints,
+  pass the `options[:unsynchronized_methods]` param with a list of method names (as symbols).
 
 ### 2.4.2
 

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -39,5 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'grpc', '~> 1.10'
   spec.add_runtime_dependency 'grpc-tools', '~> 1.10'
   spec.add_runtime_dependency 'activesupport'
+  spec.add_runtime_dependency 'concurrent-ruby'
   spec.add_runtime_dependency 'slop', '~> 4.6'
 end

--- a/lib/gruf.rb
+++ b/lib/gruf.rb
@@ -32,6 +32,7 @@ require_relative 'gruf/timer'
 require_relative 'gruf/response'
 require_relative 'gruf/error'
 require_relative 'gruf/client'
+require_relative 'gruf/synchronized_client'
 require_relative 'gruf/instrumentable_grpc_server'
 require_relative 'gruf/server'
 

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -40,6 +40,7 @@ module Gruf
       use_exception_message: true,
       internal_error_message: 'Internal Server Error',
       event_listener_proc: nil,
+      synchronized_client_internal_cache_expiry: 60,
       rpc_server_options: {
         pool_size: GRPC::RpcServer::DEFAULT_POOL_SIZE,
         max_waiting_requests: GRPC::RpcServer::DEFAULT_MAX_WAITING_REQUESTS,

--- a/lib/gruf/synchronized_client.rb
+++ b/lib/gruf/synchronized_client.rb
@@ -1,0 +1,93 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'concurrent'
+
+module Gruf
+  ##
+  # Ensures that we only have one active call to a given endpoint with a given set of params. This can be useful
+  # to mitigate thundering herds.
+  #
+  class SynchronizedClient < Gruf::Client
+    attr_reader :unsynchronized_methods
+
+    ##
+    # Initialize the client and setup the stub
+    #
+    # @param [Module] service The namespace of the client Stub that is desired to load
+    # @param [Hash] options A hash of options for the client
+    # @option options [Array] :unsynchronized_methods A list of methods (as symbols) that should be excluded from synchronization
+    # @option options [Integer] :internal_cache_expiry The length of time to keep results around for other threads to fetch (in seconds)
+    # @param [Hash] client_options A hash of options to pass to the gRPC client stub
+    #
+    def initialize(service:, options: {}, client_options: {})
+      @unsynchronized_methods = options.delete(:unsynchronized_methods) { [] }
+      @expiry = options.delete(:internal_cache_expiry) { Gruf.synchronized_client_internal_cache_expiry }
+      @locks = Concurrent::Map.new
+      @results = Concurrent::Map.new
+      super
+    end
+
+    ##
+    # Call the client's method with given params. If another call is already active for the same endpoint and the same
+    # params, block until the active call is complete. When unblocked, callers will get a copy of the original result.
+    #
+    # @param [String|Symbol] request_method The method that is being requested on the service
+    # @param [Hash] params (Optional) A hash of parameters that will be inserted into the gRPC request message that is required
+    # for the given above call
+    # @param [Hash] metadata (Optional) A hash of metadata key/values that are transported with the client request
+    # @param [Hash] opts (Optional) A hash of options to send to the gRPC request_response method
+    # @return [Gruf::Response] The response from the server
+    # @raise [Gruf::Client::Error|GRPC::BadStatus] If an error occurs, an exception will be raised according to the
+    # error type that was returned
+    #
+    def call(request_method, params = {}, metadata = {}, opts = {}, &block)
+      # Allow for bypassing extra behavior for selected methods
+      return super if unsynchronized_methods.include?(request_method.to_sym)
+
+      # Generate a unique key based on the method and params
+      key = "#{request_method}.#{params.hash}"
+
+      # Create a lock for this call if we haven't seen it already, then acquire it
+      lock = @locks.compute_if_absent(key) { Mutex.new }
+      lock.synchronize do
+        # Return value from results cache if it exists. This occurs for callers that were
+        # waiting on the lock while the first caller was making the actual grpc call.
+        response = @results.get(lock)
+        if response
+          Gruf.logger.debug "Returning cached result for #{key}:#{lock.inspect}"
+          next response
+        end
+
+        # Make the grpc call and record response for other callers that are blocked
+        # on the same lock
+        response = super
+        @results.put(lock, response)
+
+        # Schedule a task to come in later and clean out result to prevent memory bloat
+        Concurrent::ScheduledTask.new(@expiry, args: [@results, lock]) { |h, k| h.delete(k) }.execute
+
+        # Remove the lock from the map. The next caller to come through with the
+        # same params will create a new lock and start the process over again.
+        # Anyone who was waiting on this call will be using a local reference
+        # to the same lock as us, and will fetch the result from the cache.
+        @locks.delete(key)
+
+        # Return response
+        response
+      end
+    end
+  end
+end

--- a/spec/gruf/synchronized_client_spec.rb
+++ b/spec/gruf/synchronized_client_spec.rb
@@ -1,0 +1,101 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+require 'thwait'
+
+describe Gruf::SynchronizedClient do
+  let(:options) { {} }
+  subject { build_sync_client(options) }
+
+  around do |t|
+    @server = build_server
+    run_server(@server) { t.run }
+  end
+
+  describe '#initialize' do
+    context 'when no exclusion list is provided' do
+      it 'should default to an empty list' do
+        expect(subject).to be_a(described_class)
+        expect(subject.unsynchronized_methods).to eq []
+      end
+    end
+
+    context 'if exclusion list is passed' do
+      let(:excluded) { [:foo] }
+      let(:options) { { unsynchronized_methods: excluded } }
+
+      it 'should remember them' do
+        expect(subject).to be_a(described_class)
+        expect(subject.unsynchronized_methods).to eq excluded
+      end
+    end
+  end
+
+  describe '#call' do
+    let(:params) { { id: 1, sleep: 1 } }
+    let(:metadata) { {} }
+    let(:opts) { {} }
+    let(:method_name) { :GetThing }
+
+    context 'multiple calls in parallel' do
+      it 'should make only one rpc and return the same response object' do
+        threads = []
+        values = Concurrent::Map.new
+        threads << Thread.new { values.put(:t1, subject.call(method_name, params, metadata, opts)) }
+        threads << Thread.new { values.put(:t2, subject.call(method_name, params, metadata, opts)) }
+        ThreadsWait.all_waits(*threads)
+
+        expect(values[:t1]).to be_truthy
+        expect(values[:t2]).to be_truthy
+        expect(values[:t1]).to eq(values[:t2])
+      end
+    end
+
+    context 'multiple calls in series' do
+      it 'should make an rpc for both calls and return different response objects' do
+        result = subject.call(method_name, params, metadata, opts)
+        result2 = subject.call(method_name, params, metadata, opts)
+        expect(result.message).to be_truthy
+        expect(result2.message).to be_truthy
+        expect(result).to_not eq(result2)
+      end
+    end
+
+    context 'when an exception occurs' do
+      it 'should release the lock, not stall future requests, and return the same exception' do
+        values = Concurrent::Map.new
+        threads = []
+        0.upto(10) do |i|
+          threads << Thread.new do
+            value = begin
+                      subject.call(:GetFail, params, {}, {})
+                    rescue StandardError => e
+                      e
+                    end
+            values.put("result#{i}", value)
+          end
+        end
+        ThreadsWait.all_waits(*threads)
+
+        ex = values.get('result0')
+        expect(ex).to be_a(Gruf::Client::Error)
+        1.upto(10) do |i|
+          expect(values.get("result#{i}")).to eq(ex)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -67,11 +67,13 @@ module Gruf
       t = Thread.new { grpc_server.run }
       grpc_server.wait_till_running
 
-      yield
-
-      grpc_server.stop
-      sleep(0.1) until grpc_server.stopped?
-      t.join
+      begin
+        yield
+      ensure
+        grpc_server.stop
+        sleep(0.1) until grpc_server.stopped?
+        t.join
+      end
     end
 
     ##
@@ -79,6 +81,20 @@ module Gruf
     #
     def build_client(options = {})
       Gruf::Client.new(
+        service: ::Rpc::ThingService,
+        options: {
+          hostname: "0.0.0.0:#{@server.port}",
+          username: USERNAME,
+          password: PASSWORD
+        }.merge(options)
+      )
+    end
+
+    ##
+    # Builds a client
+    #
+    def build_sync_client(options = {})
+      Gruf::SynchronizedClient.new(
         service: ::Rpc::ThingService,
         options: {
           hostname: "0.0.0.0:#{@server.port}",


### PR DESCRIPTION
## What? Why?
To help with cases where you might have spikes of traffic to a given endpoint (so-called thundering herds), SynchronizedClient puts locks around Client calls to a given endpoint with the same params.

## How was it tested?
* Unit tests
* A server endpoint that uses Gruf::Client to call out to another service was updated to use Gruf::SynchronizedClient and a test client was used to generate load against it. I observed the debug logs and saw the expected behavior.
