### PR TITLE
skip params log for bidi_streamer request

### DIFF
--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
@@ -78,7 +78,7 @@ module Gruf
             end
 
             payload = {}
-            unless request.client_streamer? or request.bidi_streamer?
+            if !request.client_streamer? && !request.bidi_streamer?
               payload[:params] = sanitize(request.message.to_h) if options.fetch(:log_parameters, false)
               payload[:message] = message(request, result)
               payload[:status] = status(result.message, result.successful?)
@@ -87,6 +87,7 @@ module Gruf
               payload[:message] = ''
               payload[:status] = GRPC::Core::StatusCodes::OK
             end
+
             payload[:service] = request.service_key
             payload[:method] = request.method_key
             payload[:action] = request.method_key

--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
@@ -78,7 +78,7 @@ module Gruf
             end
 
             payload = {}
-            if !request.client_streamer?
+            unless request.client_streamer? or request.bidi_streamer?
               payload[:params] = sanitize(request.message.to_h) if options.fetch(:log_parameters, false)
               payload[:message] = message(request, result)
               payload[:status] = status(result.message, result.successful?)


### PR DESCRIPTION
## What? Why?

## protos

```
# Generated by the protocol buffer compiler.  DO NOT EDIT!
# Source: peatio/smaug/v2/account.proto for package 'peatio.smaug.v2'

require 'grpc'
require 'peatio/smaug/v2/account_pb'

module Peatio
  module Smaug
    module V2
      module Accounts
        class Service

          include GRPC::GenericService

          self.marshal_class_method = :encode
          self.unmarshal_class_method = :decode
          self.service_name = 'peatio.smaug.v2.Accounts'

          rpc :List, ListAccountsRequest, stream(Account)
          # should with a guid value in grpc metadata
          rpc :DoTransaction, stream(UpdateAccountRequest), stream(Account)
        end

        Stub = Service.rpc_stub_class
      end
    end
  end
end
```

The request and response of service are both stream type

It is a bidi_streamer request
https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/generic/rpc_desc.rb#L187

```
     # ------------------
     # --- Caused by: ---
     # TypeError:
     #   wrong element type Peatio::Smaug::V2::UpdateAccountRequest at 0 (expected array)
     #   /.rvm/gems/ruby-2.5.1/gems/gruf-2.4.0/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb:82:in `to_h'
```

## How was it tested?

Passed in my case

