### PR TITLE
Cast timeout client opt to int; attach bound service name to controller class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Ensure `timeout` is an int when passed as a client option to a gRPC client
+- Add `bound_service` reader to `Gruf::Controllers::Base` for finding the service bound to the given controller
+
 ### 2.5.0
 
 - Client exceptions raised now contain mapped subclasses, such as `Gruf::Client::Errors::InvalidArgument`

--- a/lib/gruf/client.rb
+++ b/lib/gruf/client.rb
@@ -59,6 +59,7 @@ module Gruf
       @opts[:password] = options.fetch(:password, '').to_s
       @opts[:hostname] = options.fetch(:hostname, Gruf.default_client_host)
       @error_factory = Gruf::Client::ErrorFactory.new
+      client_options[:timeout] = client_options[:timeout].to_i if client_options.key?(:timeout)
       client = "#{service}::Stub".constantize.new(@opts[:hostname], build_ssl_credentials, client_options)
       super(client)
     end

--- a/lib/gruf/controllers/base.rb
+++ b/lib/gruf/controllers/base.rb
@@ -29,6 +29,11 @@ module Gruf
       # @var [Gruf::Error] error
       attr_reader :error
 
+      class << self
+        # @var [GRPC::GenericService] bound_service
+        attr_reader :bound_service
+      end
+
       ##
       # Initialize the controller within the given request context
       #
@@ -56,8 +61,10 @@ module Gruf
       # @param [GRPC::GenericService] service The name of the service to bind this controller to
       #
       def self.bind(service)
-        Gruf.services << service.name.constantize
-        ServiceBinder.new(service).bind!(self)
+        service_class = service.name.constantize
+        Gruf.services << service_class
+        @bound_service = service_class
+        ServiceBinder.new(service_class).bind!(self)
       end
 
       ##

--- a/spec/gruf/client_spec.rb
+++ b/spec/gruf/client_spec.rb
@@ -50,6 +50,15 @@ describe Gruf::Client do
         expect(subject).to be_a(Gruf::Client)
         expect(subject.timeout).to eq timeout
       end
+
+      context 'if the timeout is passed as a string' do
+        let(:timeout) { '30' }
+
+        it 'should be cast as an int' do
+          expect(subject).to be_a(Gruf::Client)
+          expect(subject.timeout).to eq 30
+        end
+      end
     end
   end
 

--- a/spec/gruf/controllers/base_spec.rb
+++ b/spec/gruf/controllers/base_spec.rb
@@ -37,6 +37,14 @@ describe ::Gruf::Controllers::Base do
       expect(rpc_service.instance_methods).to include(:get_thing)
       expect(controller_class.instance_methods).to include(:get_thing)
     end
+
+    it 'should bind the service name to the service class' do
+      expect(controller_class.bound_service).to eq rpc_service
+    end
+
+    it 'should not bind the service name to the base class' do
+      expect(Gruf::Controllers::Base.bound_service).to be_nil
+    end
   end
 
   describe '.call' do


### PR DESCRIPTION
## What? Why?

When `timeout` is passed as a client option to `Gruf::Client`, we want to ensure it is always an int, as this is now enforced in the core gRPC library. This fixes an issue where if someone were to pass `timeout: '300'` it would cause a downstream gRPC TimeConst error.

Also, added a new `bound_service` class method to Gruf Controllers, that allows you to introspect the service being bound to the delegated controller. Given this:

```ruby
class MyRpcController < Gruf::Controllers::Base
  bind MyGrpcService
end
```

Now you can do:

```
MyRpcController.bound_service # => MyGrpcService
```

This is useful for spec testing.

----

@bigcommerce/platform-engineering @mattolson @hx @billthompson @pedelman 
