### PR TITLE
Log all server's errors in request logging

### DIFF
--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
@@ -128,7 +128,9 @@ module Gruf
           # @return [Boolean] The proper status code
           #
           def status(response, successful)
-            successful ? GRPC::Core::StatusCodes::OK : response.code
+            return GRPC::Core::StatusCodes::OK if successful
+
+            response.respond_to?(:code) ? response.code : GRPC::Core::StatusCodes::UNKNOWN
           end
 
           ##

--- a/lib/gruf/interceptors/timer.rb
+++ b/lib/gruf/interceptors/timer.rb
@@ -73,7 +73,7 @@ module Gruf
         end_time = Time.now
         elapsed = (end_time - start_time) * 1000.0
         Result.new(message, elapsed, true)
-      rescue GRPC::BadStatus => e
+      rescue StandardError => e
         end_time = Time.now
         elapsed = (end_time - start_time) * 1000.0
         Result.new(e, elapsed, false)

--- a/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
@@ -96,6 +96,21 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
         end
       end
     end
+
+    context 'and the request was unspecified failure' do
+      let(:call) do
+        interceptor.call do
+          raise NoMethodError
+        end
+      end
+
+      it 'should log the call properly as an ERROR' do
+        expect(Gruf.logger).to receive(:error).once
+        expect { subject }.to raise_error(NoMethodError) do |e|
+          expect(e.class).to eq NoMethodError
+        end
+      end
+    end
   end
 
   describe '.sanitize' do


### PR DESCRIPTION
## What? Why?

When there is unhandled server exception (e.g. NoMethodError) then no request log is logged.
Additionally, `Gruf::Interceptors::Timer` should count time always when there is error (not just `GRPC::BadStatus`)

## How was it tested?

Test :) 