### PR TITLE
Log ok/validation responses at DEBUG levels to prevent log stampeding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 dist: trusty
 rvm:
   - 2.2
-  - 2.3
   - 2.4
   - 2.5
 before_install: gem install bundler -v 1.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Log ok/validation responses at DEBUG levels to prevent log stampeding in high-volume environments
+
 ### 2.5.1
 
 - Ensure `timeout` is an int when passed as a client option to a gRPC client

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development, :test do
   gem 'factory_bot'
   gem 'ffaker'
   gem 'pry-byebug'
-  gem 'rubocop', '~> 0.53.0'
+  gem 'rubocop', '~> 0.54.0'
 end
 
 group :test do

--- a/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
@@ -30,6 +30,11 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
   let(:errors) { build :error }
   let(:interceptor) { described_class.new(controller_request, errors, options) }
   let(:call) { interceptor.call { true } }
+  let(:logger) { ::Logger.new('/dev/null') }
+
+  before do
+    allow(interceptor).to receive(:logger).and_return(logger)
+  end
 
   describe '.call' do
     subject { call }
@@ -41,8 +46,8 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
         end
       end
 
-      it 'should log the call properly as an INFO' do
-        expect(Gruf.logger).to receive(:info).once
+      it 'should log the call properly as a DEBUG' do
+        expect(logger).to receive(:debug).once
         expect { subject }.to raise_error(GRPC::InvalidArgument) do |e|
           expect(e.details).to eq 'invalid argument'
         end
@@ -59,7 +64,7 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
       end
 
       it 'should log the call properly as an WARN' do
-        expect(Gruf.logger).to receive(:warn).once
+        expect(logger).to receive(:warn).once
         expect { subject }.to raise_error(GRPC::InvalidArgument) do |e|
           expect(e.details).to eq 'invalid argument'
         end
@@ -67,8 +72,8 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
     end
 
     context 'and the request was successful' do
-      it 'should log the call properly as an INFO' do
-        expect(Gruf.logger).to receive(:info).once
+      it 'should log the call properly as a DEBUG' do
+        expect(logger).to receive(:debug).once
         subject
       end
 
@@ -76,7 +81,7 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
         let(:options) { { ignore_methods: %w[rpc.thing_service.get_thing] } }
 
         it 'shouldn\'t log the call' do
-          expect(Gruf.logger).not_to receive(:info)
+          expect(logger).not_to receive(:debug)
           subject
         end
       end
@@ -89,8 +94,8 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
         end
       end
 
-      it 'should log the call properly as an INFO' do
-        expect(Gruf.logger).to receive(:info).once
+      it 'should log the call properly as a DEBUG' do
+        expect(logger).to receive(:debug).once
         expect { subject }.to raise_error(GRPC::NotFound) do |e|
           expect(e.details).to eq 'thing not found'
         end


### PR DESCRIPTION
## What? Why?

Reduces defaults for OK/validation-level errors in the request log handler to `debug`, which prevents log stampeding in environments receiving very high traffic.

Also bumps rubocop to get rid of a warning when running.

## How was it tested?

`rspec` and through performance/regression testing.

----

@zackangelo @pedelman @mattolson @junedkazi @chrisboulton 
