### PR TITLE
Remove support for CRuby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 sudo: false
 dist: trusty
 rvm:
-  - 2.2
   - 2.4
   - 2.5
 before_install: gem install bundler -v 1.16.1

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ up fast and efficiently at scale. Some of its features include:
   still preserving gRPC BadStatus codes
 * Server and client execution timings in responses
 
-gruf currently has active support for gRPC 1.10.x+. gruf is compatible and tested with Ruby 2.2-2.5.
+gruf currently has active support for gRPC 1.10.x+. gruf is compatible and tested with Ruby 2.3-2.5.
 gruf is also not [Rails](https://github.com/rails/rails)-specific, and can be used in any Ruby framework
 (such as [Grape](https://github.com/ruby-grape/grape), for instance).
 


### PR DESCRIPTION
CI for 2.2.x failed. [Support of Ruby 2.2 has ended](https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/)
