### PR TITLE
Fix the default config in Rails environment

### DIFF
--- a/lib/gruf.rb
+++ b/lib/gruf.rb
@@ -35,6 +35,7 @@ require_relative 'gruf/client'
 require_relative 'gruf/synchronized_client'
 require_relative 'gruf/instrumentable_grpc_server'
 require_relative 'gruf/server'
+require_relative 'gruf/integrations/rails/railtie' if defined?(Rails)
 
 ##
 # Initializes configuration of gruf core module

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -57,7 +57,11 @@ module Gruf
     # Whenever this is extended into a class, setup the defaults
     #
     def self.extended(base)
-      base.reset
+      if defined?(Rails)
+        Gruf::Integrations::Rails::Railtie.config.before_initialize { base.reset }
+      else
+        base.reset
+      end
     end
 
     ##

--- a/lib/gruf/integrations/rails/railtie.rb
+++ b/lib/gruf/integrations/rails/railtie.rb
@@ -1,0 +1,8 @@
+module Gruf
+  module Integrations
+    module Rails
+      class Railtie < ::Rails::Railtie
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What? Why?

The `Configuration::reset` didn't get right configs of Rails(`Rails.logger`, `Rails.root`), we should put the `reset` in Rails initialization hook.

Before the commit:

```ruby
rails c # => Loading development environment (Rails 5.1.6)
Gruf.logger # => ...@dev=#<IO:<STDOUT>
Gruf.grpc_logger # => ...@dev=#<IO:<STDOUT>
Gruf.root_path # => ""
Gruf.controllers_path # => "app/rpc"
```

After the commit:

```ruby
rails c # => Loading development environment (Rails 5.1.6)
Gruf.logger # => ...@dev=#<File:/Users/pinewong/works/warehouse/log/development.log>
Gruf.grpc_logger # => ...@dev=#<File:/Users/pinewong/works/warehouse/log/development.log>
Gruf.root_path # => "/Users/pinewong/works/warehouse"
Gruf.controllers_path # => "/Users/pinewong/works/warehouse/app/rpc"
```