### PR TITLE
Abstract the controller :send making easy to include Rails components

### DIFF
--- a/lib/gruf/controllers/base.rb
+++ b/lib/gruf/controllers/base.rb
@@ -68,6 +68,17 @@ module Gruf
       end
 
       ##
+      # Call a method on this controller.
+      # Override this in a subclass to modify the behavior around processing a method
+      #
+      # @param [Symbol] method_key The name of the gRPC service method being called as a Symbol
+      # @param [block] &block The passed block for executing the method
+      #
+      def process_action(method_key, &block)
+        send(method_key, &block)
+      end
+
+      ##
       # Call a method on this controller
       #
       # @param [Symbol] method_key The name of the gRPC service method being called as a Symbol
@@ -75,7 +86,7 @@ module Gruf
       #
       def call(method_key, &block)
         Interceptors::Context.new(@interceptors).intercept! do
-          send(method_key, &block)
+          process_action(method_key, &block)
         end
       rescue GRPC::BadStatus
         raise # passthrough, to be caught by Gruf::Interceptors::Timer


### PR DESCRIPTION
## What? Why?

A simple abstraction on send of Controllers::Base. I want to include `AbstractController::Callbacks` of Rails on my controller and this makes easy to do it.

Why `process_action`? Because https://github.com/rails/rails/blob/v3.1.0/actionpack/lib/abstract_controller/base.rb#L166
 and https://github.com/rails/rails/blob/v3.1.0/actionpack/lib/abstract_controller/callbacks.rb#L16
## How was it tested?

It does not break the actual behavior. Here what I want to do:

```ruby
class MyController < Gruf::Controllers::Base

  include AbstractController::Callbacks

  # This is necessary because Rails default behaviors
  attr_accessor :performed
  def performed?
    @performed || false
  end

  # Rails use this method to connect with public instance methods
  def action_name
    request&.method_key.to_s
  end

  before_action :run_before
  after_action :run_after

  def my_method
    puts 'my_method is running'
  end

  def run_before
    puts 'this will run before my_method'
  end

  def run_after
    puts 'this will run after my_method'
  end
end
```

