### PR TITLE
Fix Logger in executor

### DIFF
--- a/lib/gruf/cli/executor.rb
+++ b/lib/gruf/cli/executor.rb
@@ -38,7 +38,7 @@ module Gruf
         server.start!
       rescue StandardError => e
         msg = "FATAL ERROR: #{e.message} #{e.backtrace.join("\n")}"
-        logger = Gruf.logger || Logger.new(STDERR)
+        logger = Gruf.logger || ::Logger.new(STDERR)
         logger.fatal msg
       end
 


### PR DESCRIPTION
## What? Why?

The `Logger` in module `Gruf` will explain to `Gruf::Logger`, this is not expected.

## How was it tested?

When you set `Gruf.logger` to `nil` manually, this will occur.