### PR TITLE
Add frozen_string_literal: true to files, update rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.4
   Exclude:
     - spec/**/*
     - .bundle/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -21,7 +23,7 @@ group :development, :test do
   gem 'factory_bot'
   gem 'ffaker'
   gem 'pry-byebug'
-  gem 'rubocop', '~> 0.64.0'
+  gem 'rubocop', '~> 0.68'
 end
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf.rb
+++ b/lib/gruf.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/cli/executor.rb
+++ b/lib/gruf/cli/executor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/client.rb
+++ b/lib/gruf/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -56,8 +58,8 @@ module Gruf
       @base_klass = service
       @service_klass = "#{base_klass}::Service".constantize
       @opts = options || {}
-      @opts[:password] = options.fetch(:password, '').to_s
-      @opts[:hostname] = options.fetch(:hostname, Gruf.default_client_host)
+      @opts[:password] = @opts.fetch(:password, '').to_s
+      @opts[:hostname] = @opts.fetch(:hostname, Gruf.default_client_host)
       @error_factory = Gruf::Client::ErrorFactory.new
       client_options[:timeout] = client_options[:timeout].to_i if client_options.key?(:timeout)
       client = "#{service}::Stub".constantize.new(@opts[:hostname], build_ssl_credentials, client_options)
@@ -152,7 +154,7 @@ module Gruf
     #
     def request_object(request_method, params = {})
       desc = rpc_desc(request_method)
-      desc && desc.input ? desc.input.new(params) : nil
+      desc&.input ? desc.input.new(params) : nil
     end
 
     ##
@@ -162,7 +164,7 @@ module Gruf
     #
     def call_signature(request_method)
       desc = rpc_desc(request_method)
-      desc && desc.name ? desc.name.to_s.underscore.to_sym : nil
+      desc&.name ? desc.name.to_s.underscore.to_sym : nil
     end
 
     ##

--- a/lib/gruf/client/error.rb
+++ b/lib/gruf/client/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/client/error_factory.rb
+++ b/lib/gruf/client/error_factory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -86,7 +88,7 @@ module Gruf
         return @default_class unless error_class.ancestors.include?(Gruf::Client::Errors::Base)
 
         error_class
-      rescue NameError => _
+      rescue NameError => _e
         @default_class
       end
 

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/controllers/base.rb
+++ b/lib/gruf/controllers/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/controllers/request.rb
+++ b/lib/gruf/controllers/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/controllers/service_binder.rb
+++ b/lib/gruf/controllers/service_binder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/error.rb
+++ b/lib/gruf/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -54,8 +56,8 @@ module Gruf
     # not to overflow this limit, or the response message will never
     # be sent. Instead, resource_exhausted will be thrown.
     MAX_METADATA_SIZE = 7.5 * 1_024
-    METADATA_SIZE_EXCEEDED_CODE = 'metadata_size_exceeded'.freeze
-    METADATA_SIZE_EXCEEDED_MSG = 'Metadata too long, risks exceeding http2 trailing metadata limit.'.freeze
+    METADATA_SIZE_EXCEEDED_CODE = 'metadata_size_exceeded'
+    METADATA_SIZE_EXCEEDED_MSG = 'Metadata too long, risks exceeding http2 trailing metadata limit.'
 
     # @return [Symbol] The given internal gRPC code for the error
     attr_accessor :code

--- a/lib/gruf/errors/debug_info.rb
+++ b/lib/gruf/errors/debug_info.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -34,8 +36,8 @@ module Gruf
 
         # Limit the size of the stack trace to reduce risk of overflowing metadata
         stack_trace_limit = Gruf.backtrace_limit.to_i
-        stack_trace_limit = 10 if stack_trace_limit < 0
-        @stack_trace = @stack_trace[0..stack_trace_limit] if stack_trace_limit > 0
+        stack_trace_limit = 10 if stack_trace_limit.negative?
+        @stack_trace = @stack_trace[0..stack_trace_limit] if stack_trace_limit.positive?
       end
 
       ##

--- a/lib/gruf/errors/field.rb
+++ b/lib/gruf/errors/field.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/errors/helpers.rb
+++ b/lib/gruf/errors/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/instrumentable_grpc_server.rb
+++ b/lib/gruf/instrumentable_grpc_server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Gruf
   ##
   # A subclass of GRPC::RpcServer that can be used for enhanced monitoring
@@ -36,7 +38,7 @@ module Gruf
     # Notify the event listener of something interesting
     #
     def notify(event)
-      return unless @event_listener_proc && @event_listener_proc.respond_to?(:call)
+      return if @event_listener_proc.nil? || !@event_listener_proc.respond_to?(:call)
 
       @event_listener_proc.call(event)
     end

--- a/lib/gruf/integrations/rails/railtie.rb
+++ b/lib/gruf/integrations/rails/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Gruf
   module Integrations
     module Rails

--- a/lib/gruf/interceptors/active_record/connection_reset.rb
+++ b/lib/gruf/interceptors/active_record/connection_reset.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/interceptors/authentication/basic.rb
+++ b/lib/gruf/interceptors/authentication/basic.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/interceptors/base.rb
+++ b/lib/gruf/interceptors/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/interceptors/client_interceptor.rb
+++ b/lib/gruf/interceptors/client_interceptor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/interceptors/context.rb
+++ b/lib/gruf/interceptors/context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/interceptors/instrumentation/output_metadata_timer.rb
+++ b/lib/gruf/interceptors/instrumentation/output_metadata_timer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/interceptors/instrumentation/request_logging/formatters/base.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/formatters/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/interceptors/instrumentation/request_logging/formatters/logstash.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/formatters/logstash.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/interceptors/instrumentation/request_logging/formatters/plain.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/formatters/plain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/interceptors/instrumentation/statsd.rb
+++ b/lib/gruf/interceptors/instrumentation/statsd.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/interceptors/registry.rb
+++ b/lib/gruf/interceptors/registry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/interceptors/server_interceptor.rb
+++ b/lib/gruf/interceptors/server_interceptor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/interceptors/timer.rb
+++ b/lib/gruf/interceptors/timer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/loggable.rb
+++ b/lib/gruf/loggable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/logging.rb
+++ b/lib/gruf/logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/outbound/request_context.rb
+++ b/lib/gruf/outbound/request_context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/response.rb
+++ b/lib/gruf/response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/serializers/errors/base.rb
+++ b/lib/gruf/serializers/errors/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/serializers/errors/json.rb
+++ b/lib/gruf/serializers/errors/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/server.rb
+++ b/lib/gruf/server.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/synchronized_client.rb
+++ b/lib/gruf/synchronized_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/timer.rb
+++ b/lib/gruf/timer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/version.rb
+++ b/lib/gruf/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -14,5 +16,5 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 module Gruf
-  VERSION = '2.6.0'.freeze
+  VERSION = '2.6.1.pre'
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -16,9 +17,9 @@
 #
 module Gruf
   module Helpers
-    HOST = ENV.fetch('GRPC_HOSTNAME', '0.0.0.0:0').freeze
-    USERNAME = ENV.fetch('GRPC_USERNAME', 'gruf').freeze
-    PASSWORD = ENV.fetch('GRPC_PASSWORD', 'furg').freeze
+    HOST = ENV.fetch('GRPC_HOSTNAME', '0.0.0.0:0').to_s
+    USERNAME = ENV.fetch('GRPC_USERNAME', 'gruf').to_s
+    PASSWORD = ENV.fetch('GRPC_PASSWORD', 'furg').to_s
 
     ##
     # Build a gRPC operation stub for testing


### PR DESCRIPTION
## What? Why?

Adds `frozen_string_literal: true` to the top of all files, which should ease the transition of the gem to Ruby 3.0, and ensure we're in parity with Ruby community conventions.

Also, bump rubocop to target a minimum version of Ruby 2.4 going forward, and fix appropriate cop-flagged issues.

## How was it tested?

`rspec` and `rubocop`

----

@bigcommerce/ruby @bigcommerce/oss-maintainers @bigcommerce/platform-engineering 