### PR TITLE
Add hook support for executing code paths before a server is started and after a server stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Add hook support for executing code paths before a server is started, and after a server stops
+
 ### 2.6.1
 
 - Add frozen_string_literal: true to files, update rubocop to 0.68

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -25,6 +25,7 @@ module Gruf
       server_binding_url: '0.0.0.0:9001',
       server_options: {},
       interceptors: nil,
+      hooks: nil,
       default_client_host: '',
       use_ssl: false,
       ssl_crt_file: '',
@@ -99,6 +100,7 @@ module Gruf
         send((k.to_s + '='), v)
       end
       self.interceptors = Gruf::Interceptors::Registry.new
+      self.hooks = Gruf::Hooks::Registry.new
       self.root_path = Rails.root.to_s.chomp('/') if defined?(Rails)
       if defined?(Rails) && Rails.logger
         self.logger = Rails.logger

--- a/lib/gruf/hooks/base.rb
+++ b/lib/gruf/hooks/base.rb
@@ -15,36 +15,20 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-require 'grpc'
-require 'active_support/core_ext/module/delegation'
-require 'active_support/concern'
-require 'active_support/inflector'
-require 'base64'
-require_relative 'gruf/version'
-require_relative 'gruf/logging'
-require_relative 'gruf/loggable'
-require_relative 'gruf/configuration'
-require_relative 'gruf/errors/helpers'
-require_relative 'gruf/cli/executor'
-require_relative 'gruf/controllers/base'
-require_relative 'gruf/outbound/request_context'
-require_relative 'gruf/interceptors/registry'
-require_relative 'gruf/interceptors/base'
-require_relative 'gruf/hooks/registry'
-require_relative 'gruf/hooks/executor'
-require_relative 'gruf/hooks/base'
-require_relative 'gruf/timer'
-require_relative 'gruf/response'
-require_relative 'gruf/error'
-require_relative 'gruf/client'
-require_relative 'gruf/synchronized_client'
-require_relative 'gruf/instrumentable_grpc_server'
-require_relative 'gruf/server'
-require_relative 'gruf/integrations/rails/railtie' if defined?(Rails)
-
-##
-# Initializes configuration of gruf core module
-#
 module Gruf
-  extend Configuration
+  module Hooks
+    ##
+    # Base class for a hook that allows execution at various points of Gruf server processes
+    #
+    class Base
+      include Gruf::Loggable
+
+      ##
+      # @param [Hash] options
+      #
+      def initialize(options: nil)
+        @options = options || {}
+      end
+    end
+  end
 end

--- a/lib/gruf/hooks/executor.rb
+++ b/lib/gruf/hooks/executor.rb
@@ -15,36 +15,33 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-require 'grpc'
-require 'active_support/core_ext/module/delegation'
-require 'active_support/concern'
-require 'active_support/inflector'
-require 'base64'
-require_relative 'gruf/version'
-require_relative 'gruf/logging'
-require_relative 'gruf/loggable'
-require_relative 'gruf/configuration'
-require_relative 'gruf/errors/helpers'
-require_relative 'gruf/cli/executor'
-require_relative 'gruf/controllers/base'
-require_relative 'gruf/outbound/request_context'
-require_relative 'gruf/interceptors/registry'
-require_relative 'gruf/interceptors/base'
-require_relative 'gruf/hooks/registry'
-require_relative 'gruf/hooks/executor'
-require_relative 'gruf/hooks/base'
-require_relative 'gruf/timer'
-require_relative 'gruf/response'
-require_relative 'gruf/error'
-require_relative 'gruf/client'
-require_relative 'gruf/synchronized_client'
-require_relative 'gruf/instrumentable_grpc_server'
-require_relative 'gruf/server'
-require_relative 'gruf/integrations/rails/railtie' if defined?(Rails)
-
-##
-# Initializes configuration of gruf core module
-#
 module Gruf
-  extend Configuration
+  module Hooks
+    ##
+    # Base class for a hook that allows execution at various points of gRPC server processes
+    #
+    class Executor
+      include Gruf::Loggable
+
+      def initialize(hooks: nil)
+        @hooks = hooks || Gruf.hooks&.prepare || []
+      end
+
+      ##
+      # Execute a hook point for each registered hook in the registry
+      #
+      # @param [Symbol] name
+      # @param [Hash] arguments
+      #
+      def call(name, arguments = {})
+        name = name.to_sym
+
+        @hooks.each do |hook|
+          next unless hook.respond_to?(name)
+
+          hook.send(name, arguments)
+        end
+      end
+    end
+  end
 end

--- a/lib/gruf/hooks/registry.rb
+++ b/lib/gruf/hooks/registry.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Hooks
+    ##
+    # Handles registration of hooks
+    #
+    class Registry
+      class HookNotFoundError < StandardError; end
+
+      def initialize
+        @registry = []
+      end
+
+      ##
+      # Add a hook to the registry
+      #
+      # @param [Class] hook_class The class of the hook to add
+      # @param [Hash] options A hash of options to pass into the hook during initialization
+      #
+      def use(hook_class, options = {})
+        hooks_mutex do
+          @registry << {
+            klass: hook_class,
+            options: options
+          }
+        end
+      end
+
+      ##
+      # Remove a hook from the registry
+      #
+      # @param [Class] hook_class The hook class to remove
+      # @raise [HookNotFoundError] if the hook is not found
+      #
+      def remove(hook_class)
+        pos = @registry.find_index { |opts| opts.fetch(:klass, '') == hook_class }
+        raise HookNotFoundError if pos.nil?
+
+        @registry.delete_at(pos)
+      end
+
+      ##
+      # Insert a hook before another specified hook
+      #
+      # @param [Class] before_class The hook to insert before
+      # @param [Class] hook_class The class of the hook to add
+      # @param [Hash] options A hash of options to pass into the hook during initialization
+      # @raise [HookNotFoundError] if the before hook is not found
+      #
+      def insert_before(before_class, hook_class, options = {})
+        hooks_mutex do
+          pos = @registry.find_index { |opts| opts.fetch(:klass, '') == before_class }
+          raise HookNotFoundError if pos.nil?
+
+          @registry.insert(
+            pos,
+            klass: hook_class,
+            options: options
+          )
+        end
+      end
+
+      ##
+      # Insert a hook after another specified hook
+      #
+      # @param [Class] after_class The hook to insert after
+      # @param [Class] hook_class The class of the hook to add
+      # @param [Hash] options A hash of options to pass into the hook during initialization
+      # @raise [HookNotFoundError] if the after hook is not found
+      #
+      def insert_after(after_class, hook_class, options = {})
+        hooks_mutex do
+          pos = @registry.find_index { |opts| opts.fetch(:klass, '') == after_class }
+          raise HookNotFoundError if pos.nil?
+
+          @registry.insert(
+            (pos + 1),
+            klass: hook_class,
+            options: options
+          )
+        end
+      end
+
+      ##
+      # Return a list of the hook classes in the registry in their execution order
+      #
+      # @return [Array<Class>]
+      #
+      def list
+        hooks_mutex do
+          @registry.map { |h| h[:klass] }
+        end
+      end
+
+      ##
+      # Lazily load and return all hooks for the given request
+      #
+      # @return [Array<Gruf::Hooks::Base>]
+      #
+      def prepare
+        is = []
+        hooks_mutex do
+          @registry.each do |o|
+            is << o[:klass].new(options: o[:options])
+          end
+        end
+        is
+      end
+
+      ##
+      # Clear the registry
+      #
+      def clear
+        hooks_mutex do
+          @registry = []
+        end
+      end
+
+      ##
+      # @return [Integer] The number of hooks currently loaded
+      #
+      def count
+        hooks_mutex do
+          @registry ||= []
+          @registry.count
+        end
+      end
+
+      private
+
+      ##
+      # Handle mutations to the hook registry in a thread-safe manner
+      #
+      def hooks_mutex(&block)
+        @hooks_mutex ||= begin
+          require 'monitor'
+          Monitor.new
+        end
+        @hooks_mutex.synchronize(&block)
+      end
+    end
+  end
+end

--- a/spec/demo_server
+++ b/spec/demo_server
@@ -36,6 +36,17 @@ class FakeStats
   end
 end
 
+class DemoHook < Gruf::Hooks::Base
+  def before_server_start(server:)
+    raise StandardError, 'Failed in before_server_start hook' if ENV.fetch('FAIL_IN_BEFORE_START', 0).to_i.positive?
+    Gruf.logger.info 'Executing before server start hook...'
+  end
+
+  def after_server_stop(server:)
+    Gruf.logger.info 'Executing after server stop hook...'
+  end
+end
+
 Gruf.configure do |c|
   c.server_binding_url = 'localhost:9001'
   c.error_serializer = Serializers::Proto
@@ -71,6 +82,7 @@ Gruf.configure do |c|
     pool_keep_alive: ENV.fetch('POOL_KEEP_ALIVE', 1).to_i, # 1s
     poll_period: ENV.fetch('DEFAULT_POLL_PERIOD', 1).to_i, # 1s
   }
+  c.hooks.use(DemoHook)
 end
 
 Gruf.logger = Logger.new(STDOUT)

--- a/spec/gruf/cli/executor_spec.rb
+++ b/spec/gruf/cli/executor_spec.rb
@@ -1,0 +1,74 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+describe Gruf::Cli::Executor do
+  let(:args) { [] }
+  let(:server) { double(:server, add_service: true, start!: true) }
+  let(:services) { [Rpc::ThingService::Service] }
+  let(:hook_executor) { double(:hook_executor, call: true) }
+  let(:logger) { Gruf.logger }
+  let(:executor) do
+    described_class.new(
+      args,
+      server: server,
+      services: services,
+      hook_executor: hook_executor,
+      logger: logger
+    )
+  end
+
+  describe '.run' do
+    subject { executor.run }
+
+    it 'should add each specified service to the server' do
+      services.each do |svc|
+        expect(server).to receive(:add_service).ordered.with(svc)
+      end
+      expect(hook_executor).to receive(:call).with(:before_server_start, server: server).once
+      expect(server).to receive(:start!).once
+      expect(logger).to_not receive(:fatal)
+      expect(hook_executor).to receive(:call).with(:after_server_stop, server: server).once
+      subject
+    end
+
+    context 'if the server raises an exception' do
+      let(:exception) { StandardError.new('Failure') }
+
+      before do
+        expect(server).to receive(:start!).once.and_raise(exception)
+      end
+
+      it 'should still run the pre and post hooks' do
+        expect(hook_executor).to receive(:call).with(:before_server_start, server: server).once
+        expect(logger).to receive(:fatal).once
+        expect(hook_executor).to receive(:call).with(:after_server_stop, server: server).once
+        expect { subject }.to raise_error(exception)
+      end
+    end
+
+    context 'if the before hook raises an exception' do
+      let(:exception) { StandardError.new('Failure') }
+
+      it 'should still run the post hooks' do
+        expect(hook_executor).to receive(:call).with(:before_server_start, server: server).and_raise(exception)
+        expect(logger).to receive(:fatal).once
+        expect(hook_executor).to receive(:call).with(:after_server_stop, server: server).once
+        expect { subject }.to raise_error(exception)
+      end
+    end
+  end
+end

--- a/spec/gruf/hooks/executor_spec.rb
+++ b/spec/gruf/hooks/executor_spec.rb
@@ -1,0 +1,74 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+describe Gruf::Hooks::Executor do
+  let(:hook1) { TestHook1.new }
+  let(:hook2) { TestHook2.new }
+  let(:hook3) { TestHook3.new }
+  let(:hooks) { [hook1, hook2, hook3] }
+  let(:executor) { described_class.new(hooks: hooks) }
+
+  describe '.call' do
+    let(:cmd) { :before_server_start }
+    let(:arguments) { { foo: :bar } }
+
+    subject { executor.call(cmd, arguments) }
+
+    context 'if the hook has the command' do
+      it 'should run the command for each hook' do
+        expect(hook1).to receive(:send).with(cmd, arguments).once
+        expect(hook2).to receive(:send).with(cmd, arguments).once
+        expect(hook3).to receive(:send).with(cmd, arguments).once
+        subject
+      end
+    end
+
+    context 'if the hook does not have the command' do
+      let(:cmd) { :a_fake_hook_point_that_never_exists }
+
+      it 'should not execute against hooks that do not have it defined' do
+        expect(hook1).to_not receive(:send).with(cmd, arguments)
+        subject
+      end
+    end
+
+    context 'when some hooks have the method and others do not' do
+      let(:cmd) { :after_server_stop }
+
+      it 'should run only against the appropriate hooks' do
+        expect(hook1).to receive(:send).with(cmd, arguments).once
+        expect(hook2).to receive(:send).with(cmd, arguments).once
+        expect(hook3).to_not receive(:send).with(cmd, arguments)
+        subject
+      end
+    end
+
+    context 'if the second hook raises an exception' do
+      let(:exception) { StandardError.new('Failure') }
+
+      before do
+        allow(hook2).to receive(:send).with(cmd, arguments).and_raise(exception)
+      end
+
+      it 'the third hook should not execute, but the first should' do
+        expect(hook1).to receive(:send).with(cmd, arguments).once
+        expect(hook3).to_not receive(:send).with(cmd, arguments)
+        expect { subject }.to raise_error(exception)
+      end
+    end
+  end
+end

--- a/spec/gruf/hooks/registry_spec.rb
+++ b/spec/gruf/hooks/registry_spec.rb
@@ -1,0 +1,189 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+describe Gruf::Hooks::Registry do
+  let(:registry) { described_class.new }
+  let(:hook_class) { TestHook1 }
+  let(:hook_class2) { TestHook2 }
+  let(:hook_class3) { TestHook3 }
+  let(:hook_class4) { TestHook4 }
+  let(:hook_options) { { one: 'two' } }
+
+  describe '.use' do
+    subject { registry.use(hook_class, hook_options) }
+    it 'should add the hook to the registry' do
+      expect { subject }.to_not raise_error
+      expect(registry.count).to eq 1
+      expect(registry.instance_variable_get('@registry').first).to eq(
+        klass: hook_class,
+        options: hook_options
+      )
+    end
+  end
+
+  describe '.insert_before' do
+    subject { registry.insert_before(hook_class3, hook_class4, hook_options) }
+
+    context 'when the before hook exists in the registry' do
+      before do
+        registry.use(hook_class)
+        registry.use(hook_class2)
+        registry.use(hook_class3)
+      end
+
+      it 'should insert the hook before it in the registry' do
+        expect { subject }.not_to raise_error
+
+        reg = registry.instance_variable_get('@registry')
+        expect(reg[2][:klass]).to eq(hook_class4)
+        expect(reg[3][:klass]).to eq(hook_class3)
+      end
+    end
+
+    context 'when the before hook does not exist in the registry' do
+      before do
+        registry.use(hook_class)
+        registry.use(hook_class2)
+      end
+
+      it 'should raise a HookNotFoundError' do
+        expect { subject }.to raise_error(described_class::HookNotFoundError)
+      end
+    end
+  end
+
+  describe '.insert_after' do
+    subject { registry.insert_after(hook_class2, hook_class3, hook_options) }
+
+    context 'when the before hook exists in the registry' do
+      before do
+        registry.use(hook_class)
+        registry.use(hook_class2)
+        registry.use(hook_class4)
+      end
+
+      it 'should insert the hook before it in the registry' do
+        expect { subject }.not_to raise_error
+
+        reg = registry.instance_variable_get('@registry')
+        expect(reg[2][:klass]).to eq(hook_class3)
+        expect(reg[1][:klass]).to eq(hook_class2)
+      end
+    end
+
+    context 'when the before hook does not exist in the registry' do
+      before do
+        registry.use(hook_class)
+        registry.use(hook_class4)
+      end
+
+      it 'should raise a HookNotFoundError' do
+        expect { subject }.to raise_error(described_class::HookNotFoundError)
+      end
+    end
+  end
+
+  describe '.remove' do
+    subject { registry.remove(hook_class) }
+
+    before do
+      registry.use(hook_class2)
+      registry.use(hook_class3)
+    end
+
+    context 'if the hook is in the registry' do
+      before do
+        registry.use(hook_class)
+      end
+
+      it 'should remove the hook from the registry' do
+        expect { subject }.not_to raise_error
+        expect(registry.count).to eq 2
+      end
+    end
+
+    context 'if the hook is not in the registry' do
+      it 'should raise an HookNotFoundError exception' do
+        expect { subject }.to raise_error(described_class::HookNotFoundError)
+      end
+    end
+  end
+
+  describe '.clear' do
+    subject { registry.clear }
+
+    before do
+      registry.use(hook_class)
+      registry.use(hook_class2)
+    end
+
+    it 'should clear the registry of hooks' do
+      expect { subject }.not_to raise_error
+      expect(registry.count).to be_zero
+    end
+  end
+
+  describe '.count' do
+    subject { registry.count }
+
+    context 'with no hooks' do
+      it 'should return 0' do
+        expect(subject).to be_zero
+      end
+    end
+
+    context 'with one hook' do
+      before do
+        registry.use(hook_class)
+      end
+
+      it 'should return 1' do
+        expect(subject).to eq 1
+      end
+    end
+
+    context 'with multiple hooks' do
+      before do
+        registry.use(hook_class)
+        registry.use(hook_class2)
+        registry.use(hook_class3)
+      end
+
+      it 'should return the number' do
+        expect(subject).to eq 3
+      end
+    end
+  end
+
+  describe '.prepare' do
+    subject { registry.prepare }
+
+    before do
+      registry.use(hook_class)
+      registry.use(hook_class3)
+      registry.use(hook_class2)
+    end
+
+    it 'should return all the hooks prepared by the request and maintain insertion order' do
+      prepped = subject
+      expect(prepped.count).to eq 3
+      expect(prepped[0]).to be_a(hook_class)
+      expect(prepped[1]).to be_a(hook_class3)
+      expect(prepped[2]).to be_a(hook_class2)
+    end
+  end
+end

--- a/spec/support/hooks.rb
+++ b/spec/support/hooks.rb
@@ -1,0 +1,66 @@
+# coding: utf-8
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+##########################################################################################
+# Hooks
+##########################################################################################
+class TestHook1 < ::Gruf::Hooks::Base
+  def before_server_start(server:)
+    logger.info "Got before_server_start in TestHook1: #{server.class}"
+    Math.sqrt(4)
+  end
+
+  def after_server_stop(server:)
+    logger.info "Got after_server_stop in TestHook1: #{server.class}"
+    Math.sqrt(16)
+  end
+end
+
+class TestHook2 < ::Gruf::Hooks::Base
+  def before_server_start(server:)
+    logger.info "Got before_server_start in TestHook2: #{server.class}"
+    Math.sqrt(4)
+  end
+
+  def after_server_stop(server:)
+    logger.info "Got after_server_stop in TestHook2: #{server.class}"
+    Math.sqrt(16)
+  end
+end
+
+class TestHook3 < ::Gruf::Hooks::Base
+  def before_server_start(server:)
+    logger.info "Got before_server_start in TestHook3: #{server.class}"
+    Math.sqrt(4)
+  end
+end
+
+class TestHook4 < ::Gruf::Hooks::Base
+
+end
+
+class TestFailHook1 < ::Gruf::Hooks::Base
+  def before_server_start(server:)
+    logger.info "Got before_server_start in TestFailHook1: #{server.class}"
+    raise StandardError, 'Failure'
+  end
+
+  def after_server_stop(server:)
+    logger.info "Got after_server_stop in TestFailHook1: #{server.class}"
+    raise StandardError, 'Failure'
+  end
+end


### PR DESCRIPTION
## What? Why?

Adds hook support for executing code paths before a server is started, and after a server stops, as well as a generic hook registry and base class. This allows for execution of code outside of the normal request chain, which can be used to provide server instrumentation, process monitoring, and more.

```ruby
class MyHook < Gruf::Hooks::Base
  def before_server_start(server:)
    # do my thing before the server starts  
  end
  
  def after_server_stop(server:)
    # do my thing after the server stops
  end
end

# Then in an initializer:

Gruf.configure do |c|
  c.hooks.use(MyHook, option_foo: 'value 123')
end
```

## How was it tested?

`spec/demo_server` has a successful hook implementation. Also ran against a live server and tested proper startup/shutdown, and ensured memory was released properly.

----

@bigcommerce/oss-maintainers @bigcommerce/ruby @bigcommerce/platform-engineering 