### PR TITLE
New Feature: pass GRPC::Core::ChannelCredentials when instantiating Gruf::Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Add `channel_credentials` option to `Gruf::Client` and `default_channel_credentials` option to `Gruf::Configuration` [#85] [#87]
+
 ### 2.7.0
 
 - Add hook support for executing code paths before a server is started, and after a server stops

--- a/lib/gruf/client.rb
+++ b/lib/gruf/client.rb
@@ -60,6 +60,7 @@ module Gruf
       @opts = options || {}
       @opts[:password] = @opts.fetch(:password, '').to_s
       @opts[:hostname] = @opts.fetch(:hostname, Gruf.default_client_host)
+      @opts[:channel_credentials] = @opts.fetch(:channel_credentials, Gruf.default_channel_credentials)
       @error_factory = Gruf::Client::ErrorFactory.new
       client_options[:timeout] = client_options[:timeout].to_i if client_options.key?(:timeout)
       client = "#{service}::Stub".constantize.new(@opts[:hostname], build_ssl_credentials, client_options)
@@ -190,6 +191,8 @@ module Gruf
     #
     # :nocov:
     def build_ssl_credentials
+      return opts[:channel_credentials] if opts[:channel_credentials]
+      
       cert = nil
       if opts[:ssl_certificate_file]
         cert = File.read(opts[:ssl_certificate_file]).to_s.strip

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -26,6 +26,7 @@ module Gruf
       server_options: {},
       interceptors: nil,
       hooks: nil,
+      default_channel_credentials: nil,
       default_client_host: '',
       use_ssl: false,
       ssl_crt_file: '',

--- a/spec/gruf/client_spec.rb
+++ b/spec/gruf/client_spec.rb
@@ -41,6 +41,44 @@ describe Gruf::Client do
         expect(subject.opts[:hostname]).to eq 'test.dev'
       end
     end
+    
+    context 'when no channel credentials options are passed' do
+      let(:channel_credentials) { GRPC::Core::ChannelCredentials.new }
+      
+      after do
+        Gruf.configure do |config|
+          config.default_channel_credentials = nil
+        end
+      end
+      
+      it 'should return nil' do
+        expect(subject).to be_a(Gruf::Client)
+        expect(subject.opts[:channel_credentials]).to be_nil
+      end
+      
+      it 'should use default channel credentials' do
+        Gruf.configure do |config|
+          config.default_channel_credentials = channel_credentials
+        end
+        
+        expect(subject).to be_a(Gruf::Client)
+        expect(subject.opts[:channel_credentials]).to eq(channel_credentials)
+      end
+    end
+    
+    context 'when channel credentials options are passed' do
+      let(:channel_credentials) { GRPC::Core::ChannelCredentials.new }
+      let(:options) { { channel_credentials: channel_credentials } }
+      
+      after do
+        subject.opts[:channel_credentials] = nil
+      end
+      
+      it 'should set channel credentials' do
+        expect(subject).to be_a(Gruf::Client)
+        expect(subject.opts[:channel_credentials]).to eq(channel_credentials)
+      end
+    end
 
     context 'if client options are passed' do
       let(:timeout) { 30 }


### PR DESCRIPTION
### Summary

This PR resolves #85 by adding a new option (`channel_credentials`) to the `Gruf::Client` class and a corresponding default (`default_channel_credentials`) to the `Gruf::Configuration` module.

These changes were implemented in response to @splittingred's [feedback on #85](https://github.com/bigcommerce/gruf/issues/85#issuecomment-560463847):

> I think allowing passing a `GRPC::Core::ChannelCredentials` is reasonable, as long as we maintain backwards support for the current implementation.

**Note:** I didn't include a check that `channel_credentials` are an instance of `GRPC::Core::ChannelCredentials`, so the assumption is that end users pass in the appropriate value. Happy to add that sort of check, though, if y'all think it'd be helpful.

Thanks for considering this addition to Gruf!

### Usage

When creating a new client, pass `channel_credentials` as an option. Its value should be an instance of `GRPC::Core::ChannelCredentials`:

```rb
# https://github.com/grpc/grpc/blob/master/src/ruby/ext/grpc/rb_channel_credentials.c#L141-L143
#
# pem_root_certs: (optional) PEM encoding of the server root certificate
# pem_private_key: (optional) PEM encoding of the client's private key
# pem_cert_chain: (optional) PEM encoding of the client's cert chain

creds = GRPC::Core::ChannelCredentials.new(pem_root_certs, pem_private_key, pem_cert_chain)

client = Gruf::Client.new(service: :PhotosService, options: { channel_credentials: creds })
```

_Or_, set a default set of credentials using the `default_channel_credentials` option:

```rb
# In, say, `./config/initializers/gruf.rb`
Gruf.configure do |config|
  config.default_channel_credentials = GRPC::Core::ChannelCredentials.new(pem_root_certs, pem_private_key, pem_cert_chain)
end

# In, say, `./app/controllers/photos_controller.rb
def client
  @client ||= Gruf::Client.new(service: :PhotosService)
end
```
