### PR TITLE
Pass the controller request and response into the request logging formatters [#92]

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,7 +22,7 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 12
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Metrics/MethodLength:
@@ -43,3 +43,7 @@ Naming/PredicateName:
 Metrics/BlockLength:
   Enabled: false
 
+# Rubocop is opinionated here, which makes compositional base classes/interfaces with keyword arguments problematic.
+# Disabling this allows base class stub methods to have keyword args.
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Pass the controller request object into the request logging formatters [#92]  
+
 ### 2.7.1
 
 - Add `channel_credentials` option to `Gruf::Client` and `default_channel_credentials` option to `Gruf::Configuration` [#85] [#87]

--- a/lib/gruf/interceptors/instrumentation/request_logging/formatters/base.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/formatters/base.rb
@@ -28,9 +28,11 @@ module Gruf
             # Format the parameters into a loggable string. Must be implemented in every derivative class
             #
             # @param [Hash] _payload The incoming request payload
+            # @param [Gruf::Controllers::Request] request The current controller request
+            # @param [Gruf::Interceptors::Timer::Result] result The timed result of the response
             # @return [String] The formatted string
             #
-            def format(_payload)
+            def format(_payload, request:, result:)
               raise NotImplementedError
             end
           end

--- a/lib/gruf/interceptors/instrumentation/request_logging/formatters/logstash.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/formatters/logstash.rb
@@ -30,9 +30,11 @@ module Gruf
             # Format the request into a JSON-friendly payload
             #
             # @param [Hash] payload The incoming request payload
+            # @param [Gruf::Controllers::Request] request The current controller request
+            # @param [Gruf::Interceptors::Timer::Result] result The timed result of the response
             # @return [String] The JSON representation of the payload
             #
-            def format(payload)
+            def format(payload, request:, result:)
               payload.merge(format: 'json').to_json
             end
           end

--- a/lib/gruf/interceptors/instrumentation/request_logging/formatters/plain.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/formatters/plain.rb
@@ -28,9 +28,11 @@ module Gruf
             # Format the request by only outputting the message body and params (if set to log params)
             #
             # @param [Hash] payload The incoming request payload
+            # @param [Gruf::Controllers::Request] request The current controller request
+            # @param [Gruf::Interceptors::Timer::Result] result The timed result of the response
             # @return [String] The formatted string
             #
-            def format(payload)
+            def format(payload, request:, result:)
               time = payload.fetch(:duration, 0)
               grpc_status = payload.fetch(:grpc_status, 'GRPC::Ok')
               route_key = payload.fetch(:method, 'unknown')

--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
@@ -100,7 +100,7 @@ module Gruf
             payload[:time] = Time.now.to_s
             payload[:host] = Socket.gethostname
 
-            logger.send(type, formatter.format(payload))
+            logger.send(type, formatter.format(payload, request: request, result: result))
 
             raise result.message unless result.successful?
 

--- a/spec/demo_server
+++ b/spec/demo_server
@@ -86,9 +86,9 @@ Gruf.configure do |c|
 end
 
 Gruf.logger = Logger.new(STDOUT)
-Gruf.logger.level = Logger::Severity::INFO
+Gruf.logger.level = Logger::Severity::DEBUG
 Gruf.grpc_logger = Logger.new(STDOUT)
-Gruf.grpc_logger.level = Logger::Severity::DEBUG
+Gruf.grpc_logger.level = Logger::Severity::INFO
 Gruf.services << ::Rpc::ThingService::Service
 
 cli = Gruf::Cli::Executor.new

--- a/spec/gruf/interceptors/instrumentation/request_logging/formatters/base_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/formatters/base_spec.rb
@@ -18,10 +18,12 @@ require 'spec_helper'
 
 describe Gruf::Interceptors::Instrumentation::RequestLogging::Formatters::Base do
   let(:formatter) { described_class.new }
+  let(:request) { build :controller_request }
+  let(:result) { Gruf::Interceptors::Timer.time { Rpc::GetThingResponse.new } }
   let(:payload) { {} }
 
   describe '.format' do
-    subject { formatter.format(payload) }
+    subject { formatter.format(payload, request: request, result: result) }
 
     it 'should raise a NotImplementedError' do
       expect { subject }.to raise_error(NotImplementedError)

--- a/spec/gruf/interceptors/instrumentation/request_logging/formatters/logstash_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/formatters/logstash_spec.rb
@@ -18,10 +18,12 @@ require 'spec_helper'
 
 describe Gruf::Interceptors::Instrumentation::RequestLogging::Formatters::Logstash do
   let(:formatter) { described_class.new }
+  let(:request) { build :controller_request }
+  let(:result) { Gruf::Interceptors::Timer.time { Rpc::GetThingResponse.new } }
   let(:payload) { { message: 'foo', params: {one: 2} } }
 
   describe '.format' do
-    subject { formatter.format(payload) }
+    subject { formatter.format(payload, request: request, result: result) }
 
     it 'should return the payload as a JSON object' do
       expect(subject).to eq payload.merge(format: 'json').to_json

--- a/spec/gruf/interceptors/instrumentation/request_logging/formatters/plain_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/formatters/plain_spec.rb
@@ -23,10 +23,12 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Formatters::Plain 
   let(:execution_time) { 0.001 }
   let(:message) { 'foo' }
   let(:params) { { id: 1 } }
+  let(:request) { build :controller_request }
+  let(:result) { Gruf::Interceptors::Timer.time { Rpc::GetThingResponse.new } }
   let(:payload) { { message: message, status: status, method: route_key, duration: execution_time, params: params } }
 
   describe '.format' do
-    subject { formatter.format(payload) }
+    subject { formatter.format(payload, request: request, result: result) }
 
     context 'when params are sent to the formatter' do
       it 'should return the message, without params' do

--- a/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
@@ -135,7 +135,7 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
       end
 
       context 'with nested blacklist' do
-        let(:blacklist) { ['data.array', 'hello'] }
+        let(:blacklist) { %w[data.array hello] }
         let(:options) { { blacklist: blacklist } }
 
         it 'should support nested filtering' do


### PR DESCRIPTION
## What? Why?

Addresses #92 by passing the controller request and response into request logging formatters.

## How was it tested?

Specs, and starting demo server, issuing requests. Ensure everything works properly.

----

@bigcommerce/oss-maintainers @zinosama @bigcommerce/ruby 

