### PR TITLE
Fix issue where CLI --suppress-default-interceptors was ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Fix issue with --suppress-default-interceptors not working [#95]
+
 ### 2.8.0
 
 - Pass the controller request object into the request logging formatters [#92]  

--- a/lib/gruf/cli/executor.rb
+++ b/lib/gruf/cli/executor.rb
@@ -67,7 +67,23 @@ module Gruf
       # Setup options for CLI execution and configure Gruf based on inputs
       #
       def setup!
-        opts = Slop.parse(@args) do |o|
+        opts = parse_options
+
+        Gruf.server_binding_url = opts[:host] if opts[:host]
+        if opts.suppress_default_interceptors?
+          Gruf.interceptors.remove(Gruf::Interceptors::ActiveRecord::ConnectionReset)
+          Gruf.interceptors.remove(Gruf::Interceptors::Instrumentation::OutputMetadataTimer)
+        end
+        Gruf.backtrace_on_error = true if opts.backtrace_on_error?
+      end
+
+      ##
+      # Parse all CLI arguments into an options result
+      #
+      # @return [Slop::Result]
+      #
+      def parse_options
+        ::Slop.parse(@args) do |o|
           o.null '-h', '--help', 'Display help message' do
             puts o
             exit(0)
@@ -80,10 +96,6 @@ module Gruf
             exit(0)
           end
         end
-
-        Gruf.server_binding_url = opts[:host] if opts[:host]
-        Gruf.use_default_interceptors = false if opts.suppress_default_interceptors?
-        Gruf.backtrace_on_error = true if opts.backtrace_on_error?
       end
     end
   end

--- a/spec/gruf/cli/executor_spec.rb
+++ b/spec/gruf/cli/executor_spec.rb
@@ -70,5 +70,75 @@ describe Gruf::Cli::Executor do
         expect { subject }.to raise_error(exception)
       end
     end
+
+  end
+
+  describe '.setup!' do
+    let(:interceptors) { Gruf.interceptors.list }
+
+    subject { executor }
+
+    before do
+      Gruf.reset
+    end
+
+    context 'if --host is' do
+      context 'passed' do
+        let(:args) { %w[--host 0.0.0.0:9999] }
+
+        it 'should set server_binding_url to the host' do
+          subject
+          expect(Gruf.server_binding_url).to eq '0.0.0.0:9999'
+        end
+      end
+
+      context 'not passed' do
+        let(:args) { [] }
+
+        it 'should set server_binding_url to the default host' do
+          subject
+          expect(Gruf.server_binding_url).to eq '0.0.0.0:9001'
+        end
+      end
+    end
+
+    context 'if --suppress-default-interceptors is' do
+      context 'passed' do
+        let(:args) { %w[--suppress-default-interceptors] }
+
+        it 'should unset the default interceptors' do
+          subject
+          expect(interceptors).to be_empty
+        end
+      end
+
+      context 'not passed' do
+        let(:args) { [] }
+
+        it 'should leave the default interceptors intact' do
+          subject
+          expect(interceptors.count).to eq 2
+          expect(interceptors).to include(Gruf::Interceptors::ActiveRecord::ConnectionReset)
+          expect(interceptors).to include(Gruf::Interceptors::Instrumentation::OutputMetadataTimer)
+        end
+      end
+    end
+
+    context 'if --backtrace-on-error is' do
+      context 'passed' do
+        let(:args) { %w[--backtrace-on-error] }
+        it 'should set backtrace_on_error to true' do
+          subject
+          expect(Gruf.backtrace_on_error).to be_truthy
+        end
+      end
+
+      context 'not passed' do
+        it 'should leave backtrace_on_error at the default value' do
+          subject
+          expect(Gruf.backtrace_on_error).to be_falsey
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## What? Why?

Due to the way the configuration elements are loaded in Gruf, the CLI executor is not respecting --suppress-default-interceptors. This fixes that issue, and adds tests for it (and all other CLI args).

## How was it tested?

`bin/gruf --suppress-default-interceptors`, prying in to ensure success, and also through rspec tests.

----

@bigcommerce/oss-maintainers @bigcommerce/ruby @bigcommerce/platform-engineering @alikinir

