### PR TITLE
Bump rake to a looser dependency to handle CVE-2020-8130

### DIFF
--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.4'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency 'pry', '~> 0.11'
 
   spec.add_runtime_dependency 'grpc', '~> 1.10'


### PR DESCRIPTION
## What? Why?

Loosens rake dependency to handle CVE alert.

## How was it tested?

CircleCI.

----

@bigcommerce/oss-maintainers @bigcommerce/ruby @bigcommerce/platform-engineering 
