### PR TITLE
Improve demo server test code, more clearly show how to stream

### DIFF
--- a/spec/demo_server
+++ b/spec/demo_server
@@ -48,7 +48,7 @@ class DemoHook < Gruf::Hooks::Base
 end
 
 Gruf.configure do |c|
-  c.server_binding_url = 'localhost:9001'
+  c.server_binding_url = 'localhost:8001'
   c.error_serializer = Serializers::Proto
   c.backtrace_on_error = true
   c.interceptors.use(

--- a/spec/pb/thing_controller.rb
+++ b/spec/pb/thing_controller.rb
@@ -28,11 +28,12 @@ class ThingController < ::Gruf::Controllers::Base
   end
 
   def get_things
-    things = []
+    return enum_for(:get_things) unless block_given?
+
     5.times do
-      things << Rpc::Thing.new(id: rand(1..1000).to_i, name: FFaker::Lorem.word.to_s)
+      yield Rpc::Thing.new(id: rand(1..1000).to_i, name: FFaker::Lorem.word.to_s)
+      sleep rand(0..1)
     end
-    things
   end
 
   def create_things
@@ -44,11 +45,12 @@ class ThingController < ::Gruf::Controllers::Base
   end
 
   def create_things_in_stream
-    things = []
+    return enum_for(:create_things_in_stream) unless block_given?
+
     request.messages.each do |msg|
-      things << Rpc::Thing.new(id: msg.id.to_i, name: msg.name.to_s)
+      yield Rpc::Thing.new(id: msg.id.to_i, name: msg.name.to_s)
+      sleep rand(0..1)
     end
-    things
   end
 
   # Error calls


### PR DESCRIPTION
## What? Why?

Improves the demo server test code and Rakefile clients to more clearly show how to do streamed request/responses and bidi streams.

## How was it tested?

`spec/demo_server` in one shell, then the various rake tasks:

- `rake gruf:demo:get_thing` - unary
- `rake gruf:demo:get_things` - server streamer
- `rake gruf:demo:create_things` - client streamer
- `rake gruf:demo:create_things_in_stream` - bidi

----

@bigcommerce/oss-maintainers @bigcommerce/ruby @bigcommerce/platform-engineering 