### PR TITLE
Explicitly declare json dependency, fixes #108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Explicitly declare [json gem](https://rubygems.org/gems/json) dependency
+
 ### 2.8.1
 
 - Fix issue with --suppress-default-interceptors not working [#95]

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'grpc', '~> 1.10'
   spec.add_runtime_dependency 'grpc-tools', '~> 1.10'
   spec.add_runtime_dependency 'activesupport', '> 4'
+  spec.add_runtime_dependency 'json', '>= 2.3'
 
   spec.add_runtime_dependency 'concurrent-ruby', '> 1'
   spec.add_runtime_dependency 'slop', '~> 4.6'


### PR DESCRIPTION
## What? Why?

Explicitly declare the [json gem](https://rubygems.org/gems/json) dependency in the gemspec.

## How was it tested?

rspec, starting server, issuing requests, etc.

----

@bigcommerce/platform-engineering @bigcommerce/ruby @bigcommerce/oss-maintainers 

