### PR TITLE
Add Ruby 2.7 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,19 +18,25 @@ executors:
     parameters:
       ruby-version:
         type: string
-        default: "2.4.6"
+        default: "2.4.9"
   ruby_2_5:
     <<: *ruby_env
     parameters:
       ruby-version:
         type: string
-        default: "2.5.5"
+        default: "2.5.8"
   ruby_2_6:
     <<: *ruby_env
     parameters:
       ruby-version:
         type: string
-        default: "2.6.3"
+        default: "2.6.6"
+  ruby_2_7:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "2.7.1"
 
 commands:
   pre-setup:
@@ -39,12 +45,18 @@ commands:
       - checkout
   bundle-install:
     steps:
+      - run:
+          name: "Install bundler 1.17.3"
+          command: |
+            echo 'export BUNDLER_VERSION=1.17.3' >> $BASH_ENV
+            source $BASH_ENV
+            gem install bundler:1.17.3
       - restore_cache:
           keys:
             - gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
             - gem-cache-{{ arch }}-{{ .Branch }}
             - gem-cache
-      - run: bundle check || bundle install --path vendor/bundle
+      - run: bundle check --path vendor/bundle || bundle install --path vendor/bundle
       - save_cache:
           key: gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
@@ -144,3 +156,14 @@ workflows:
       - rspec-unit:
           name: "ruby-2_6-rspec"
           e: "ruby_2_6"
+  ruby_2_7:
+    jobs:
+      - bundle-audit:
+          name: "ruby-2_7-bundle_audit"
+          e: "ruby_2_7"
+      - rubocop:
+          name: "ruby-2_7-rubocop"
+          e: "ruby_2_7"
+      - rspec-unit:
+          name: "ruby-2_7-rspec"
+          e: "ruby_2_7"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,9 @@ commands:
   rubocop:
     steps:
       - run: bundle exec rubocop -p
+  e2e:
+    steps:
+      - run: ./script/e2e
 
 jobs:
   bundle-audit:
@@ -98,7 +101,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -108,7 +111,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -118,11 +121,21 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
       - rspec-unit
+  e2e:
+    executor: <<parameters.e>>
+    parameters:
+      e:
+        type: executor
+        default: "ruby_2_6"
+    steps:
+      - pre-setup
+      - bundle-install
+      - e2e
 
 workflows:
   version: 2
@@ -130,10 +143,16 @@ workflows:
     jobs:
       - bundle-audit:
           name: "ruby-2_4-bundle_audit"
+          e: "ruby_2_4"
       - rubocop:
           name: "ruby-2_4-rubocop"
+          e: "ruby_2_4"
       - rspec-unit:
           name: "ruby-2_4-rspec"
+          e: "ruby_2_4"
+      - e2e:
+          name: "ruby-2_4-e2e"
+          e: "ruby_2_4"
   ruby_2_5:
     jobs:
       - bundle-audit:
@@ -144,6 +163,9 @@ workflows:
           e: "ruby_2_5"
       - rspec-unit:
           name: "ruby-2_5-rspec"
+          e: "ruby_2_5"
+      - e2e:
+          name: "ruby-2_5-e2e"
           e: "ruby_2_5"
   ruby_2_6:
     jobs:
@@ -156,6 +178,9 @@ workflows:
       - rspec-unit:
           name: "ruby-2_6-rspec"
           e: "ruby_2_6"
+      - e2e:
+          name: "ruby-2_6-e2e"
+          e: "ruby_2_6"
   ruby_2_7:
     jobs:
       - bundle-audit:
@@ -166,4 +191,7 @@ workflows:
           e: "ruby_2_7"
       - rspec-unit:
           name: "ruby-2_7-rspec"
+          e: "ruby_2_7"
+      - e2e:
+          name: "ruby-2_7-e2e"
           e: "ruby_2_7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Add Ruby 2.7 support
+- Explicitly declare development dependencies
+- Add script/e2e test for full e2e test 
 - Explicitly declare [json gem](https://rubygems.org/gems/json) dependency
 
 ### 2.8.1

--- a/Gemfile
+++ b/Gemfile
@@ -18,18 +18,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-group :development, :test do
-  gem 'factory_bot'
-  gem 'ffaker'
-  gem 'pry-byebug'
-  gem 'rubocop', '~> 0.68'
-end
-
-group :test do
-  gem 'bundler-audit'
-  gem 'null-logger'
-  gem 'rspec', '~> 3.8'
-  gem 'rspec_junit_formatter', '~> 0.4.1'
-  gem 'simplecov', require: false
-end

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ up fast and efficiently at scale. Some of its features include:
   still preserving gRPC BadStatus codes
 * Server and client execution timings in responses
 
-gruf currently has active support for gRPC 1.10.x+. gruf is compatible and tested with Ruby 2.2-2.6.
+gruf currently has active support for gRPC 1.10.x+. gruf is compatible and tested with Ruby 2.2-2.7.
 gruf is also not [Rails](https://github.com/rails/rails)-specific, and can be used in any Ruby framework
 (such as [Grape](https://github.com/ruby-grape/grape) or [dry-rb](https://dry-rb.org/), for instance).
 

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -36,8 +36,14 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.4'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler-audit', '>= 0.6'
   spec.add_development_dependency 'rake', '>= 10.0'
-  spec.add_development_dependency 'pry', '~> 0.11'
+  spec.add_development_dependency 'null-logger', '>= 0.1'
+  spec.add_development_dependency 'pry', '~> 0.12'
+  spec.add_development_dependency 'rspec', '>= 3.8'
+  spec.add_development_dependency 'rspec_junit_formatter', '>= 0.4'
+  spec.add_development_dependency 'rubocop', '>= 0.68'
+  spec.add_development_dependency 'simplecov', '>= 0.16'
 
   spec.add_runtime_dependency 'grpc', '~> 1.10'
   spec.add_runtime_dependency 'grpc-tools', '~> 1.10'
@@ -46,4 +52,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'concurrent-ruby', '> 1'
   spec.add_runtime_dependency 'slop', '~> 4.6'
+  spec.add_runtime_dependency 'thwait', '~> 0.1'
+  spec.add_runtime_dependency 'e2mmap', '~> 0.1'
 end

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -37,9 +37,12 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'bundler-audit', '>= 0.6'
+  spec.add_development_dependency 'factory_bot', '>= 5.2'
+  spec.add_development_dependency 'ffaker', '>= 2.15'
   spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency 'null-logger', '>= 0.1'
   spec.add_development_dependency 'pry', '~> 0.12'
+  spec.add_development_dependency 'pry-byebug', '>= 3.9'
   spec.add_development_dependency 'rspec', '>= 3.8'
   spec.add_development_dependency 'rspec_junit_formatter', '>= 0.4'
   spec.add_development_dependency 'rubocop', '>= 0.68'

--- a/lib/gruf/client.rb
+++ b/lib/gruf/client.rb
@@ -63,7 +63,7 @@ module Gruf
       @opts[:channel_credentials] = @opts.fetch(:channel_credentials, Gruf.default_channel_credentials)
       @error_factory = Gruf::Client::ErrorFactory.new
       client_options[:timeout] = client_options[:timeout].to_i if client_options.key?(:timeout)
-      client = "#{service}::Stub".constantize.new(@opts[:hostname], build_ssl_credentials, client_options)
+      client = "#{service}::Stub".constantize.new(@opts[:hostname], build_ssl_credentials, **client_options)
       super(client)
     end
 

--- a/lib/gruf/controllers/request.rb
+++ b/lib/gruf/controllers/request.rb
@@ -58,7 +58,7 @@ module Gruf
       # @param [Class] service The class of the service being executed against
       # @param [GRPC::RpcDesc] rpc_desc The RPC descriptor of the call
       # @param [GRPC::ActiveCall] active_call The restricted view of the call
-      # @param [Object] message The protobuf message (or messages) of the request
+      # @param [Object|Google::Protobuf::MessageExts] message The protobuf message (or messages) of the request
       #
       def initialize(method_key:, service:, rpc_desc:, active_call:, message:)
         @method_key = method_key

--- a/lib/gruf/hooks/executor.rb
+++ b/lib/gruf/hooks/executor.rb
@@ -39,7 +39,7 @@ module Gruf
         @hooks.each do |hook|
           next unless hook.respond_to?(name)
 
-          hook.send(name, arguments)
+          hook.send(name, **arguments)
         end
       end
     end

--- a/lib/gruf/server.rb
+++ b/lib/gruf/server.rb
@@ -69,9 +69,9 @@ module Gruf
 
           server = if @event_listener_proc
                      server_options[:event_listener_proc] = @event_listener_proc
-                     Gruf::InstrumentableGrpcServer.new(server_options)
+                     Gruf::InstrumentableGrpcServer.new(**server_options)
                    else
-                     GRPC::RpcServer.new(server_options)
+                     GRPC::RpcServer.new(**server_options)
                    end
 
           @port = server.add_http2_port(@hostname, ssl_credentials)

--- a/script/e2e
+++ b/script/e2e
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -o errexit
+green='\033[0;32m'
+no_color='\033[0m'
+
+ok() {
+    echo -e "$green$1$no_color"
+}
+
+ok "Beginning full e2e test..."
+
+ok "Installing gems..."
+bundle install
+
+ok "Starting gruf server..."
+spec/demo_server &
+server_pid=$!
+
+sleep 5 # let the server start
+ok "Running unary test..."
+bundle exec rake gruf:demo:get_thing
+ok "Running server streamer test..."
+bundle exec rake gruf:demo:get_things
+ok "Running client streamer test..."
+bundle exec rake gruf:demo:create_things
+ok "Running bidi streamer test..."
+bundle exec rake gruf:demo:create_things_in_stream
+
+ok "Tests successful! Shutting down server..."
+kill -9 $server_pid
+ok "Server shutdown, E2E test finished successfully."

--- a/script/test
+++ b/script/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+bundle install
+bundle exec bundle-audit update
+bundle exec bundle-audit check -v
+bundle exec rubocop -P -c ./.rubocop.yml
+bundle exec rspec

--- a/spec/factories/controllers/request.rb
+++ b/spec/factories/controllers/request.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     active_call { Rpc::Test::Call.new }
     message { Rpc::GetThingResponse.new }
 
-    initialize_with { new(attributes) }
+    initialize_with { new(**attributes) }
     skip_create
   end
 end


### PR DESCRIPTION
## What? Why?

* Adds Ruby 2.7 support for gruf
* Explicitly declare development dependencies in gemspec as opposed to Gemfile
* Update methods passing hashes as keyword args to use double splats for 2.7 support. Note: some of the deprecation warnings still exist because of FactoryBot in tests, and in grpc core as well: https://github.com/grpc/grpc/pull/22915 - This specific deprecation warning is likely to be an issue for a _lot_ of gems, but is generally harmless.

Also adds two unit and end-to-end test scripts that can be used to verify functional operation of gruf beyond just the test suite.

## How was it tested?

See spec tests and e2e test script.

---

@bigcommerce/platform-engineering @bigcommerce/ruby @bigcommerce/oss-maintainers 