### PR TITLE
Accept multiple word class logging formatter name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 - Add script/e2e test for full e2e test 
 - Explicitly declare [json gem](https://rubygems.org/gems/json) dependency
 
+### 2.8.2
+
+- Accept multiple word logging formatter class name [#113]
+
 ### 2.8.1
 
 - Fix issue with --suppress-default-interceptors not working [#95]

--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
@@ -151,7 +151,7 @@ module Gruf
               @formatter = case fmt
                            when Symbol
                              prefix = 'Gruf::Interceptors::Instrumentation::RequestLogging::Formatters::'
-                             klass = "#{prefix}#{fmt.to_s.capitalize}"
+                             klass = "#{prefix}#{fmt.to_s.classify}"
                              fmt = klass.constantize.new
                            when Class
                              fmt = fmt.new

--- a/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
@@ -169,6 +169,20 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
         end
       end
 
+      context 'and has multiple words name' do
+        before do 
+          module Gruf::Interceptors::Instrumentation::RequestLogging::Formatters
+            class MultipleWord < Base; end
+          end
+        end
+
+        let(:options) { { formatter: :multiple_word } }
+
+        it 'should return the formatter' do
+          expect(subject).to be_a(Gruf::Interceptors::Instrumentation::RequestLogging::Formatters::MultipleWord)
+        end
+      end
+
       context 'and is invalid' do
         let(:options) { { formatter: :bar } }
 


### PR DESCRIPTION
## What? Why?
For now, if I want to make a custom Logger class, I can not specify it in the interceptor as
```ruby
Gruf.configure do |c|
  c.interceptors.use(
    Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor,
    formatter: :multiple_word_logger_class_name
  )
end
```
This PR fixes that one by using `classify`

## How was it tested?
- All test should pass 🍏 
