### PR TITLE
Change to racially neutral terminology across library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Change to racially neutral terminology across library
+  - blacklist->blocklist
+  - master->main
 - Add Ruby 2.7 support
 - Explicitly declare development dependencies
 - Add script/e2e test for full e2e test 
@@ -150,11 +153,11 @@ Gruf 2.0 is a major shift from Gruf 1.0. See [UPGRADING.md](UPGRADING.md) for de
 ### 1.2.4
 
 - Loosen explicit Protobuf dependency now that 3.4.0.2 is released
-- Guard against nil params in logger blacklist
+- Guard against nil params in logger blocklist
 
 ### 1.2.3
 
-- Support nested blacklist parameters in path.to.key format
+- Support nested blocklist parameters in path.to.key format
 
 ### 1.2.2
 
@@ -176,7 +179,7 @@ Gruf 2.0 is a major shift from Gruf 1.0. See [UPGRADING.md](UPGRADING.md) for de
 - Add configuration to set the error message when an uncaught exception is
   handled by gruf.
 - Add a request logging hook for Rails-style request logging, with optional
-  parameter logging, blacklists, and formatter support
+  parameter logging, blocklists, and formatter support
 - Optimizations around Symbol casting within service calls
 
 ### 1.1.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # gruf - gRPC Ruby Framework
 
-[![CircleCI](https://circleci.com/gh/bigcommerce/gruf/tree/master.svg?style=svg)](https://circleci.com/gh/bigcommerce/gruf/tree/master) [![Gem Version](https://badge.fury.io/rb/gruf.svg)](https://badge.fury.io/rb/gruf) [![Documentation](https://inch-ci.org/github/bigcommerce/gruf.svg?branch=master)](https://inch-ci.org/github/bigcommerce/gruf?branch=master)
+[![CircleCI](https://circleci.com/gh/bigcommerce/gruf/tree/main.svg?style=svg)](https://circleci.com/gh/bigcommerce/gruf/tree/main) [![Gem Version](https://badge.fury.io/rb/gruf.svg)](https://badge.fury.io/rb/gruf) [![Documentation](https://inch-ci.org/github/bigcommerce/gruf.svg?branch=main)](https://inch-ci.org/github/bigcommerce/gruf?branch=main)
 
-gruf is a Ruby framework that wraps the [gRPC Ruby library](https://github.com/grpc/grpc/tree/master/src/ruby) to
+gruf is a Ruby framework that wraps the [gRPC Ruby library](https://github.com/grpc/grpc/tree/main/src/ruby) to
 provide a more streamlined integration into Ruby and Ruby on Rails applications.
 
 It provides an abstracted server and client for gRPC services, along with other tools to help get gRPC services in Ruby

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -155,8 +155,8 @@ Gruf.configure do |c|
 end
 ```
 
-If you want to log parameters, we recommend setting a blacklist to ensure you don't accidentally
+If you want to log parameters, we recommend setting a blocklist to ensure you don't accidentally
 log sensitive data.
 
-We also recommend blacklisting parameters that may contain very large values (such as binary
+We also recommend blocklisting parameters that may contain very large values (such as binary
 or json data).

--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
@@ -164,26 +164,26 @@ module Gruf
           end
 
           ##
-          # Redact any blacklisted params and return an updated hash
+          # Redact any blocklisted params and return an updated hash
           #
           # @param [Hash] params The hash of parameters to sanitize
           # @return [Hash] The sanitized params in hash form
           #
           def sanitize(params = {})
-            blacklists = options.fetch(:blacklist, []).map(&:to_s)
+            blocklists = options.fetch(:blocklist, []).map(&:to_s)
             redacted_string = options.fetch(:redacted_string, 'REDACTED')
-            blacklists.each do |blacklist|
-              parts = blacklist.split('.').map(&:to_sym)
+            blocklists.each do |blocklist|
+              parts = blocklist.split('.').map(&:to_sym)
               redact!(parts, 0, params, redacted_string)
             end
             params
           end
 
           ##
-          # Helper method to recursively redact based on the black list
+          # Helper method to recursively redact based on the blocklist
           #
-          # @param [Array] parts The blacklist. ex. 'data.schema' -> [:data, :schema]
-          # @param [Integer] idx The current index of the blacklist
+          # @param [Array] parts The blocklist. ex. 'data.schema' -> [:data, :schema]
+          # @param [Integer] idx The current index of the blocklist
           # @param [Hash] params The hash of parameters to sanitize
           # @param [String] redacted_string The custom redact string
           #

--- a/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
@@ -113,11 +113,11 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
       end
     end
 
-    context 'with a blacklist' do
-      let(:blacklist) { [:foo] }
-      let(:options) { { blacklist: blacklist } }
+    context 'with a blocklist' do
+      let(:blocklist) { [:foo] }
+      let(:options) { { blocklist: blocklist } }
 
-      it 'should return all params that are not filtered by the blacklist' do
+      it 'should return all params that are not filtered by the blocklist' do
         expected = params.dup
         expected[:foo] = 'REDACTED'
         expect(subject).to eq expected
@@ -125,18 +125,18 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
 
       context 'with a custom redacted string' do
         let(:str) { 'goodbye' }
-        let(:options) { { blacklist: blacklist, redacted_string: str } }
+        let(:options) { { blocklist: blocklist, redacted_string: str } }
 
-        it 'should return all params that are not filtered by the blacklist' do
+        it 'should return all params that are not filtered by the blocklist' do
           expected = params.dup
           expected[:foo] = str
           expect(subject).to eq expected
         end
       end
 
-      context 'with nested blacklist' do
-        let(:blacklist) { %w[data.array hello] }
-        let(:options) { { blacklist: blacklist } }
+      context 'with nested blocklist' do
+        let(:blocklist) { %w[data.array hello] }
+        let(:options) { { blocklist: blocklist } }
 
         it 'should support nested filtering' do
           expected = Marshal.load(Marshal.dump(params))


### PR DESCRIPTION
## What? Why?

Terminology within gruf should not be racially insensitive or discriminatory. This moves gruf away from any racially discriminatory language, such as:

- `blacklist` becomes `blocklist`
- `master` will be changed to `main` after this PR is merged.

Note that systems using the blocklist functionality in the RequestLogging interceptor will need to adjust their reference to the parameter. We are preferring to have that be a forced changed rather than provide an upgrade path, to properly remove the biased language from the library in entirety.

## How was it tested?

rspec, running e2e tests.

----

@bigcommerce/platform-engineering @bigcommerce/ruby @bigcommerce/oss-maintainers 

