### PR TITLE
Update to Rubocop 1.4, add in rubocop-rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,14 +1,20 @@
 AllCops:
   TargetRubyVersion: 2.4
   Exclude:
-    - spec/**/*
     - .bundle/**/*
     - bin/**/*
     - vendor/**/*
     - tmp/**/*
     - log/**/*
-    - Rakefile
-    - gruf.gemspec
+    - spec/support/**/*
+    - spec/factories/**/*
+    - spec/fixtures/**/*
+    - spec/pb/**/*
+    - spec/demo_server
+require:
+  - rubocop-performance
+  - rubocop-rspec
+  - rubocop-thread_safety
 
 Layout/EndAlignment:
   Enabled: false
@@ -47,3 +53,55 @@ Metrics/BlockLength:
 # Disabling this allows base class stub methods to have keyword args.
 Lint/UnusedMethodArgument:
   AllowUnusedKeywordArguments: true
+
+# This cop also affects hash keys, which is bad as we can't always control that. Disabling.
+Naming/VariableNumber:
+  Enabled: false
+
+# We're fine with this
+ThreadSafety/NewThread:
+  Enabled: false
+
+# Not necessary
+Layout/EmptyLineBetweenDefs:
+  Enabled: false
+
+####################################################################################################
+# RSpec Configurations
+####################################################################################################
+
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+
+RSpec/MultipleExpectations:
+  Max: 30
+
+RSpec/NamedSubject:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Max: 50
+
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/StubbedMock:
+  Enabled: false
+
+# This does not work with RPC messages
+RSpec/VerifiedDoubles:
+  Enabled: false
+
+RSpec/DescribeClass:
+  Exclude:
+    - spec/gruf/functional/**/*
+
+RSpec/IteratedExpectation:
+  Exclude:
+    - spec/gruf/functional/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
-- Update to Rubocop 1.0
 - Change to racially neutral terminology across library
   - blacklist->blocklist
   - master->main
@@ -10,6 +9,7 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 - Explicitly declare development dependencies
 - Add script/e2e test for full e2e test 
 - Explicitly declare [json gem](https://rubygems.org/gems/json) dependency
+- Update to Rubocop 1.4, add in rubocop-rspec for spec tests
 
 ### 2.8.1
 

--- a/Rakefile
+++ b/Rakefile
@@ -24,16 +24,18 @@ require 'gruf'
 
 def gruf_rake_configure_rpc!
   require 'pry'
-  $LOAD_PATH.unshift File.expand_path('../spec/pb', __FILE__)
-  require File.realpath("#{File.dirname(__FILE__)}/spec/support/grpc.rb")
-  require File.realpath("#{File.dirname(__FILE__)}/spec/support/serializers/proto.rb")
-  require File.realpath("#{File.dirname(__FILE__)}/spec/support/interceptors.rb")
+  $LOAD_PATH.unshift File.expand_path('spec/pb', __dir__)
+  root = File.dirname(__FILE__)
+  require File.realpath("#{root}/spec/support/grpc.rb")
+  require File.realpath("#{root}/spec/support/serializers/proto.rb")
+  require File.realpath("#{root}/spec/support/interceptors.rb")
 
   Gruf.configure do |c|
     c.error_serializer = Serializers::Proto
   end
 end
 
+# Test enumerator
 class ThingCreatorEnumerator
   def initialize(num: 10)
     @num = num.to_i
@@ -60,7 +62,7 @@ namespace :gruf do
       begin
         rpc_client = gruf_demo_build_client
         op = rpc_client.call(:GetThing, id: rand(100_000))
-        Gruf.logger.info "#{op.message.inspect}"
+        Gruf.logger.info op.message.inspect
       rescue Gruf::Client::Error => e
         Gruf.logger.info e.error.to_h
       end
@@ -87,7 +89,7 @@ namespace :gruf do
         rpc_client = gruf_demo_build_client
         enumerator = ThingCreatorEnumerator.new
         resp = rpc_client.call(:CreateThings, enumerator.each)
-        Gruf.logger.info "#{resp.message.inspect}"
+        Gruf.logger.info resp.message.inspect
       rescue Gruf::Client::Error => e
         Gruf.logger.error e.error.to_h
       end

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -15,7 +15,7 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-$:.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 require 'gruf/version'
 
 Gem::Specification.new do |spec|
@@ -30,31 +30,37 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/bigcommerce/gruf'
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf.gemspec']
-  spec.executables   << 'gruf'
+  spec.executables << 'gruf'
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '~> 2.4'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'bundler-audit', '>= 0.6'
-  spec.add_development_dependency 'factory_bot', (Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5') ? '>= 6.1' : '~> 5.2')
+  # rubocop:disable Gemspec/RubyVersionGlobalsUsage
+  spec.add_development_dependency(
+    'factory_bot',
+    (Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5') ? '>= 6.1' : '~> 5.2')
+  )
+  # rubocop:enable Gemspec/RubyVersionGlobalsUsage
   spec.add_development_dependency 'ffaker', '>= 2.15'
-  spec.add_development_dependency 'rake', '>= 10.0'
-  spec.add_development_dependency 'null-logger', '>= 0.1'
   spec.add_development_dependency 'pry', '~> 0.12'
   spec.add_development_dependency 'pry-byebug', '>= 3.9'
+  spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency 'rspec', '>= 3.8'
   spec.add_development_dependency 'rspec_junit_formatter', '>= 0.4'
   spec.add_development_dependency 'rubocop', '>= 1.0'
+  spec.add_development_dependency 'rubocop-performance', '>= 0.0.1'
+  spec.add_development_dependency 'rubocop-rspec', '>= 2.0'
+  spec.add_development_dependency 'rubocop-thread_safety', '>= 0.3'
   spec.add_development_dependency 'simplecov', '>= 0.16'
 
+  spec.add_runtime_dependency 'activesupport', '> 4'
+  spec.add_runtime_dependency 'concurrent-ruby', '> 1'
+  spec.add_runtime_dependency 'e2mmap', '~> 0.1'
   spec.add_runtime_dependency 'grpc', '~> 1.10'
   spec.add_runtime_dependency 'grpc-tools', '~> 1.10'
-  spec.add_runtime_dependency 'activesupport', '> 4'
   spec.add_runtime_dependency 'json', '>= 2.3'
-
-  spec.add_runtime_dependency 'concurrent-ruby', '> 1'
   spec.add_runtime_dependency 'slop', '~> 4.6'
   spec.add_runtime_dependency 'thwait', '~> 0.1'
-  spec.add_runtime_dependency 'e2mmap', '~> 0.1'
 end

--- a/lib/gruf/controllers/base.rb
+++ b/lib/gruf/controllers/base.rb
@@ -65,7 +65,9 @@ module Gruf
       def self.bind(service)
         service_class = service.name.constantize
         Gruf.services << service_class
+        # rubocop:disable ThreadSafety/InstanceVariableInClassMethod
         @bound_service = service_class
+        # rubocop:enable ThreadSafety/InstanceVariableInClassMethod
         ServiceBinder.new(service_class).bind!(self)
       end
 

--- a/lib/gruf/controllers/service_binder.rb
+++ b/lib/gruf/controllers/service_binder.rb
@@ -38,7 +38,7 @@ module Gruf
       ##
       # Bind all methods on the service to the passed controller
       #
-      # @param [Gruf::Controllers::Base] controller
+      # @param [Class<Gruf::Controllers::Base>] controller
       #
       def bind!(controller)
         rpc_methods.each { |name, desc| bind_method(controller, name, desc) }

--- a/spec/demo_server
+++ b/spec/demo_server
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -22,8 +23,8 @@ require 'bundler'
 Bundler.setup
 require 'active_support/all'
 require 'gruf'
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-$LOAD_PATH.unshift File.expand_path('../pb', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+$LOAD_PATH.unshift File.expand_path('pb', __dir__)
 require File.realpath("#{File.dirname(__FILE__)}/support/grpc.rb")
 require File.realpath("#{File.dirname(__FILE__)}/support/serializers/proto.rb")
 
@@ -85,9 +86,9 @@ Gruf.configure do |c|
   c.hooks.use(DemoHook)
 end
 
-Gruf.logger = Logger.new(STDOUT)
+Gruf.logger = Logger.new($stdout)
 Gruf.logger.level = Logger::Severity::DEBUG
-Gruf.grpc_logger = Logger.new(STDOUT)
+Gruf.grpc_logger = Logger.new($stdout)
 Gruf.grpc_logger.level = Logger::Severity::INFO
 Gruf.services << ::Rpc::ThingService::Service
 

--- a/spec/factories/controllers/request.rb
+++ b/spec/factories/controllers/request.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/spec/factories/errors.rb
+++ b/spec/factories/errors.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/spec/gruf/cli/executor_spec.rb
+++ b/spec/gruf/cli/executor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -31,28 +33,28 @@ describe Gruf::Cli::Executor do
     )
   end
 
-  describe '.run' do
+  describe '#run' do
     subject { executor.run }
 
-    it 'should add each specified service to the server' do
+    it 'adds each specified service to the server' do
       services.each do |svc|
         expect(server).to receive(:add_service).ordered.with(svc)
       end
       expect(hook_executor).to receive(:call).with(:before_server_start, server: server).once
       expect(server).to receive(:start!).once
-      expect(logger).to_not receive(:fatal)
+      expect(logger).not_to receive(:fatal)
       expect(hook_executor).to receive(:call).with(:after_server_stop, server: server).once
       subject
     end
 
-    context 'if the server raises an exception' do
+    context 'when the server raises an exception' do
       let(:exception) { StandardError.new('Failure') }
 
       before do
-        expect(server).to receive(:start!).once.and_raise(exception)
+        allow(server).to receive(:start!).once.and_raise(exception)
       end
 
-      it 'should still run the pre and post hooks' do
+      it 'still runs the pre and post hooks' do
         expect(hook_executor).to receive(:call).with(:before_server_start, server: server).once
         expect(logger).to receive(:fatal).once
         expect(hook_executor).to receive(:call).with(:after_server_stop, server: server).once
@@ -60,62 +62,61 @@ describe Gruf::Cli::Executor do
       end
     end
 
-    context 'if the before hook raises an exception' do
+    context 'when the before hook raises an exception' do
       let(:exception) { StandardError.new('Failure') }
 
-      it 'should still run the post hooks' do
+      it 'still runs the post hooks' do
         expect(hook_executor).to receive(:call).with(:before_server_start, server: server).and_raise(exception)
         expect(logger).to receive(:fatal).once
         expect(hook_executor).to receive(:call).with(:after_server_stop, server: server).once
         expect { subject }.to raise_error(exception)
       end
     end
-
   end
 
-  describe '.setup!' do
-    let(:interceptors) { Gruf.interceptors.list }
-
+  describe '#setup!' do
     subject { executor }
+
+    let(:interceptors) { Gruf.interceptors.list }
 
     before do
       Gruf.reset
     end
 
-    context 'if --host is' do
-      context 'passed' do
+    context 'when --host is' do
+      context 'when --host is passed' do
         let(:args) { %w[--host 0.0.0.0:9999] }
 
-        it 'should set server_binding_url to the host' do
+        it 'sets server_binding_url to the host' do
           subject
           expect(Gruf.server_binding_url).to eq '0.0.0.0:9999'
         end
       end
 
-      context 'not passed' do
+      context 'when --host is not passed' do
         let(:args) { [] }
 
-        it 'should set server_binding_url to the default host' do
+        it 'sets server_binding_url to the default host' do
           subject
           expect(Gruf.server_binding_url).to eq '0.0.0.0:9001'
         end
       end
     end
 
-    context 'if --suppress-default-interceptors is' do
-      context 'passed' do
+    context 'when --suppress-default-interceptors is' do
+      context 'when --suppress-default-interceptors is passed' do
         let(:args) { %w[--suppress-default-interceptors] }
 
-        it 'should unset the default interceptors' do
+        it 'unsets the default interceptors' do
           subject
           expect(interceptors).to be_empty
         end
       end
 
-      context 'not passed' do
+      context 'when --suppress-default-interceptors is not passed' do
         let(:args) { [] }
 
-        it 'should leave the default interceptors intact' do
+        it 'leaves the default interceptors intact' do
           subject
           expect(interceptors.count).to eq 2
           expect(interceptors).to include(Gruf::Interceptors::ActiveRecord::ConnectionReset)
@@ -124,17 +125,18 @@ describe Gruf::Cli::Executor do
       end
     end
 
-    context 'if --backtrace-on-error is' do
-      context 'passed' do
+    context 'when --backtrace-on-error is' do
+      context 'when --backtrace-on-error is passed' do
         let(:args) { %w[--backtrace-on-error] }
-        it 'should set backtrace_on_error to true' do
+
+        it 'sets backtrace_on_error to true' do
           subject
           expect(Gruf.backtrace_on_error).to be_truthy
         end
       end
 
-      context 'not passed' do
-        it 'should leave backtrace_on_error at the default value' do
+      context 'when --backtrace-on-error is not passed' do
+        it 'leaves backtrace_on_error at the default value' do
           subject
           expect(Gruf.backtrace_on_error).to be_falsey
         end

--- a/spec/gruf/client/error_factory_spec.rb
+++ b/spec/gruf/client/error_factory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -27,20 +29,21 @@ describe Gruf::Client::ErrorFactory do
     )
   end
 
-  describe '.from_exception' do
+  describe '#from_exception' do
+    subject { factory.from_exception(exception) }
+
     let(:error_message) { FFaker::Lorem.sentence }
     let(:exception) { GRPC::NotFound.new(error_message) }
 
-    subject { factory.from_exception(exception) }
-
-
     context 'when the exception is a BadStatus' do
-      Gruf::Client::Errors.constants.reject {|e| [:Error, :Validation, :Exception, :Base].include?(e) }.each do |error_class|
+      Gruf::Client::Errors.constants
+                          .reject { |e| %i[Error Validation Exception Base].include?(e) }
+                          .each do |error_class|
         context "and is a GRPC::#{error_class} exception" do
           let(:exception) { "GRPC::#{error_class}".constantize.new(error_message) }
           let(:expected_class) { "Gruf::Client::Errors::#{error_class}".constantize }
 
-          it "should wrap it with the Gruf::Client::Errors::#{error_class} class" do
+          it "wraps it with the Gruf::Client::Errors::#{error_class} class" do
             expect(subject).to be_a(expected_class)
             expect(subject.error).to eq exception
           end
@@ -51,7 +54,7 @@ describe Gruf::Client::ErrorFactory do
     context 'when the exception is a StandardError' do
       let(:exception) { StandardError.new(error_message) }
 
-      it 'should wrap it in the default exception class' do
+      it 'wraps it in the default exception class' do
         expect(subject).to be_a(default_class)
         expect(subject.error).to eq exception
       end
@@ -60,7 +63,7 @@ describe Gruf::Client::ErrorFactory do
     context 'when the exception is a GRPC::Core::CallError' do
       let(:exception) { GRPC::Core::CallError.new(error_message) }
 
-      it 'should wrap it in the default exception class' do
+      it 'wraps it in the default exception class' do
         expect(subject).to be_a(default_class)
         expect(subject.error).to eq exception
       end
@@ -69,7 +72,7 @@ describe Gruf::Client::ErrorFactory do
     context 'when the exception is a SignalException' do
       let(:exception) { SignalException.new('HUP') }
 
-      it 'should return the original exception' do
+      it 'returns the original exception' do
         expect(subject).to eq exception
       end
     end

--- a/spec/gruf/configuration_spec.rb
+++ b/spec/gruf/configuration_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -19,52 +20,56 @@ require 'spec_helper'
 class TestConfiguration
   include Gruf::Configuration
 end
+
 describe Gruf::Configuration do
   let(:obj) { TestConfiguration.new }
 
-  describe '.reset' do
+  describe '#reset' do
     subject { obj.server_binding_url }
 
-    it 'should reset config vars to default' do
+    it 'resets config vars to default' do
       obj.configure do |c|
         c.server_binding_url = 'test.dev'
       end
       obj.reset
-      expect(subject).to_not eq 'test.dev'
+      expect(subject).not_to eq 'test.dev'
     end
   end
 
   describe '.environment' do
     subject { obj.send(:environment) }
 
-    context 'ENV RAILS_ENV' do
+    context 'with ENV RAILS_ENV' do
       before do
         allow(ENV).to receive(:[]).with('RACK_ENV').and_return nil
         allow(ENV).to receive(:[]).with('RAILS_ENV').and_return 'production'
       end
-      it 'should return the proper environment' do
+
+      it 'returns the proper environment' do
         expect(subject).to eq 'production'
       end
     end
 
-    context 'ENV RACK_ENV' do
+    context 'with ENV RACK_ENV' do
       before do
         allow(ENV).to receive(:[]).with('RACK_ENV').and_return 'production'
         allow(ENV).to receive(:[]).with('RAILS_ENV').and_return nil
       end
-      it 'should return the proper environment' do
+
+      it 'returns the proper environment' do
         expect(subject).to eq 'production'
       end
     end
   end
 
-  describe '.options' do
+  describe '#options' do
     subject { obj.options }
+
     before do
       obj.reset
     end
 
-    it 'should return the options hash' do
+    it 'returns the options hash' do
       expect(obj.options).to be_a(Hash)
       expect(obj.options[:server_binding_url]).to eq '0.0.0.0:9001'
     end

--- a/spec/gruf/controllers/base_spec.rb
+++ b/spec/gruf/controllers/base_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -32,30 +33,30 @@ describe ::Gruf::Controllers::Base do
   end
 
   describe '#bind' do
-    it 'should bind the controller to the service and generate the methods' do
+    it 'binds the controller to the service and generates the methods' do
       expect(Gruf.services).to include(rpc_service)
       expect(rpc_service.instance_methods).to include(:get_thing)
       expect(controller_class.instance_methods).to include(:get_thing)
     end
 
-    it 'should bind the service name to the service class' do
+    it 'binds the service name to the service class' do
       expect(controller_class.bound_service).to eq rpc_service
     end
 
-    it 'should not bind the service name to the base class' do
+    it 'does not bind the service name to the base class' do
       expect(Gruf::Controllers::Base.bound_service).to be_nil
     end
   end
 
-  describe '.call' do
+  describe '#call' do
     subject { controller.call(:get_thing) }
 
-    it 'should expose the methods properly' do
+    it 'exposes the methods properly' do
       expect(subject).to be_a(Rpc::GetThingResponse)
     end
 
     context 'when there are interceptors' do
-      it 'should pass the request to interceptors' do
+      it 'passes the request to interceptors' do
         Gruf.interceptors.use(TestServerInterceptor)
         expect(subject).to be_a(Rpc::GetThingResponse)
       end
@@ -68,7 +69,7 @@ describe ::Gruf::Controllers::Base do
         allow(controller).to receive(:get_thing).and_raise(GRPC::NotFound, error_message)
       end
 
-      it 'should passthrough the error' do
+      it 'passes through the error' do
         expect { subject }.to raise_error(GRPC::NotFound) do |e|
           expect(e.message).to eq "#{GRPC::Core::StatusCodes::NOT_FOUND}:#{error_message}"
         end
@@ -83,7 +84,7 @@ describe ::Gruf::Controllers::Base do
         allow(controller).to receive(:get_thing).and_raise(StandardError, error_message)
       end
 
-      it 'should raise a GRPC::Internal error' do
+      it 'raises a GRPC::Internal error' do
         expect { subject }.to raise_error(GRPC::Internal) do |e|
           expect(e.code).to eq GRPC::Core::StatusCodes::INTERNAL
           expect(e.message).to eq "#{GRPC::Core::StatusCodes::INTERNAL}:#{error_message}"
@@ -96,11 +97,11 @@ describe ::Gruf::Controllers::Base do
           Gruf.backtrace_on_error = true
         end
 
-        it 'should attach a backtrace' do
+        it 'attaches a backtrace' do
           expect { subject }.to raise_error(GRPC::Internal) do |e|
             parsed_error = JSON.parse(e.metadata[:'error-internal-bin'])
-            expect(parsed_error['debug_info']).to_not be_empty
-            expect(parsed_error['debug_info']['stack_trace']).to_not be_empty
+            expect(parsed_error['debug_info']).not_to be_empty
+            expect(parsed_error['debug_info']['stack_trace']).not_to be_empty
           end
         end
       end
@@ -113,7 +114,7 @@ describe ::Gruf::Controllers::Base do
           Gruf.internal_error_message = error_message
         end
 
-        it 'should raise a GRPC::Internal error with the correct message' do
+        it 'raises a GRPC::Internal error with the correct message' do
           expect { subject }.to raise_error(GRPC::Internal) do |e|
             expect(e).to be_a(GRPC::Internal)
             expect(e.code).to eq GRPC::Core::StatusCodes::INTERNAL
@@ -127,7 +128,7 @@ describe ::Gruf::Controllers::Base do
           Gruf.use_exception_message = false
         end
 
-        it 'should raise a GRPC::Internal error and use e.message' do
+        it 'raises a GRPC::Internal error and uses e.message' do
           expect { subject }.to raise_error(GRPC::Internal) do |e|
             expect(e).to be_a(GRPC::Internal)
             expect(e.code).to eq GRPC::Core::StatusCodes::INTERNAL

--- a/spec/gruf/controllers/request_spec.rb
+++ b/spec/gruf/controllers/request_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -33,98 +34,98 @@ describe ::Gruf::Controllers::Request do
     )
   end
 
-  describe '.service_key' do
+  describe '#service_key' do
     subject { request.service_key }
 
-    it 'should return the translated name' do
+    it 'returns the translated name' do
       expect(subject).to eq 'rpc.thing_service'
     end
   end
 
-  describe '.service' do
+  describe '#service' do
     subject { request.service }
 
-    it 'should return the service class name' do
+    it 'returns the service class name' do
       expect(subject).to eq service
     end
   end
 
-  describe '.method_name' do
+  describe '#method_name' do
     subject { request.method_name }
 
-    it 'should return the translated service and method name' do
+    it 'returns the translated service and method name' do
       expect(subject).to eq 'rpc.thing_service.get_thing'
     end
   end
 
-  describe '.request_class' do
+  describe '#request_class' do
     subject { request.request_class }
 
-    it 'should return the gRPC request class' do
+    it 'returns the gRPC request class' do
       expect(subject).to eq Rpc::GetThingRequest
     end
   end
 
-  describe '.response_class' do
+  describe '#response_class' do
     subject { request.response_class }
 
-    it 'should return the gRPC response class' do
+    it 'returns the gRPC response class' do
       expect(subject).to eq Rpc::GetThingResponse
     end
   end
 
-  describe '.messages' do
+  describe '#messages' do
     subject { request.messages }
 
-    context 'for a request/response type' do
-      it 'should return the message in an array' do
+    context 'when it is a request/response type' do
+      it 'returns the message in an array' do
         expect(subject).to eq [message]
       end
     end
 
-    context 'for a client streamer type' do
+    context 'when it is a client streamer type' do
       let(:rpc_desc) { Rpc::ThingService::Service.rpc_descs[:CreateThings] }
       let(:messages) { [Rpc::Thing.new(id: 1), Rpc::Thing.new(id: 2)] }
       let(:message) { proc { messages } }
 
-      it 'should return the messages' do
+      it 'returns the messages' do
         expect(subject).to eq messages
       end
     end
 
-    context 'for a server streamer type' do
+    context 'when it is a server streamer type' do
       let(:rpc_desc) { Rpc::ThingService::Service.rpc_descs[:GetThings] }
       let(:message) { Rpc::GetThingsRequest.new }
 
-      it 'should return the request message in an array' do
+      it 'returns the request message in an array' do
         expect(subject).to eq [message]
       end
     end
 
-    context 'for a bidi streamer type' do
+    context 'when it is a bidi streamer type' do
       let(:rpc_desc) { Rpc::ThingService::Service.rpc_descs[:CreateThingsInStream] }
-      let(:messages) { [Rpc::Thing.new(id: 1), Rpc::Thing.new(id: 2)]  }
+      let(:messages) { [Rpc::Thing.new(id: 1), Rpc::Thing.new(id: 2)] }
       let(:message) { messages }
 
-      it 'should return the messages' do
+      it 'returns the messages' do
         expect(subject).to eq messages
       end
     end
   end
 
-  describe '.metadata' do
+  describe '#metadata' do
     subject { request.metadata }
 
-    it 'should delegate to the call' do
+    it 'delegates to the active call' do
       expect(subject).to eq active_call.metadata
     end
   end
 
-  describe '.metadata=' do
+  describe '#metadata=' do
     subject { request.metadata[:foo] = 'bar' }
 
-    it 'should delegate to the call' do
-      expect { subject }.to_not raise_error
+    it 'delegates to the active call' do
+      expect { subject }.not_to raise_error
       expect(request.metadata[:foo]).to eq 'bar'
     end
   end

--- a/spec/gruf/errors/helpers_spec.rb
+++ b/spec/gruf/errors/helpers_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -32,14 +33,14 @@ describe ::Gruf::Errors::Helpers do
     )
   end
 
-  describe '.fail!' do
+  describe '#fail!' do
+    subject { controller.fail!(error_code, app_code, error_message, metadata) }
+
     let(:error_code) { :not_found }
     let(:error_message) { 'Thing 1 not found!' }
     let(:app_code) { :thing_not_found }
 
-    subject { controller.fail!(error_code, app_code, error_message, metadata) }
-
-    it 'should call fail! on the error and set the appropriate values' do
+    it 'calls fail! on the error and sets the appropriate values' do
       expect { subject }.to raise_error(GRPC::NotFound) do |e|
         expect(e.code).to eq GRPC::Core::StatusCodes::NOT_FOUND
         expect(e.message).to eq "#{GRPC::Core::StatusCodes::NOT_FOUND}:#{error_message}"
@@ -53,7 +54,7 @@ describe ::Gruf::Errors::Helpers do
     end
   end
 
-  describe '.has_field_errors?' do
+  describe '#has_field_errors?' do
     subject { controller.has_field_errors? }
 
     context 'when there are field errors' do
@@ -61,35 +62,35 @@ describe ::Gruf::Errors::Helpers do
         controller.add_field_error(:name, :invalid, 'Invalid name')
       end
 
-      it 'should return true' do
+      it 'returns true' do
         expect(subject).to be_truthy
       end
     end
 
     context 'when there are no field errors' do
-      it 'should return false' do
+      it 'returns false' do
         expect(subject).to be_falsey
       end
     end
   end
 
-  describe '.set_debug_info' do
+  describe '#set_debug_info' do
+    subject { controller.set_debug_info(detail, stack_trace) }
+
     let(:detail) { FFaker::Lorem.sentence }
     let(:stack_trace) { FFaker::Lorem.sentences(2) }
     let(:error) { controller.error }
 
-    subject { controller.set_debug_info(detail, stack_trace) }
-
-    it 'should pass through to the error call' do
+    it 'passes through to the error call' do
       expect(error).to receive(:set_debug_info).with(detail, stack_trace)
       subject
     end
   end
 
-  describe '.error' do
+  describe '#error' do
     subject { controller.error }
 
-    it 'should return a Gruf::Error object' do
+    it 'returns a Gruf::Error object' do
       expect(subject).to be_a(Gruf::Error)
     end
   end

--- a/spec/gruf/functional/interception_spec.rb
+++ b/spec/gruf/functional/interception_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -26,7 +27,7 @@ describe 'Functional interceptors test' do
 
   context 'when there is an interceptor added' do
     context 'with a request/response call' do
-      it 'should intercept the call', run_thing_server: true do
+      it 'intercepts the call', run_thing_server: true do
         expect_any_instance_of(interceptor_class).to receive(:call).once.and_call_original
         client = build_client
         resp = client.call(:GetThing)
@@ -35,7 +36,7 @@ describe 'Functional interceptors test' do
     end
 
     context 'with a server streamer call' do
-      it 'should intercept the call', run_thing_server: true do
+      it 'intercepts the call', run_thing_server: true do
         expect_any_instance_of(interceptor_class).to receive(:call).and_call_original
         client = build_client
         resp = client.call(:GetThings)
@@ -47,7 +48,7 @@ describe 'Functional interceptors test' do
     end
 
     context 'with a client streamer call' do
-      it 'should intercept the call', run_thing_server: true do
+      it 'intercepts the call', run_thing_server: true do
         expect_any_instance_of(interceptor_class).to receive(:call).and_call_original
 
         things = []
@@ -66,7 +67,7 @@ describe 'Functional interceptors test' do
     end
 
     context 'with a bidi streamer call' do
-      it 'should intercept the call', run_thing_server: true do
+      it 'intercepts the call', run_thing_server: true do
         expect_any_instance_of(interceptor_class).to receive(:call).and_call_original
         things = []
         5.times do

--- a/spec/gruf/functional/server_spec.rb
+++ b/spec/gruf/functional/server_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -28,10 +29,10 @@ describe 'Functional server test' do
   describe 'request types' do
     let(:client) { TestClient.new }
 
-    context 'for a request/response call' do
+    context 'when it is a request/response call' do
       let(:id) { 1 }
 
-      it 'should return the thing', run_thing_server: true do
+      it 'returns the thing', run_thing_server: true do
         client = build_client
         resp = client.call(:GetThing, id: id)
         expect(resp.message).to be_a(Rpc::GetThingResponse)
@@ -40,18 +41,18 @@ describe 'Functional server test' do
       end
     end
 
-    context 'for a server streaming call' do
-      it 'should return the things in a stream from the server', run_thing_server: true do
+    context 'when it is a server streaming call' do
+      it 'returns the things in a stream from the server', run_thing_server: true do
         client = build_client
         resp = client.call(:GetThings)
-        resp.message.each do |r|
-          expect(r).to be_a(Rpc::Thing)
+        resp.message do |m|
+          expect(m).to be_a(Rpc::Thing)
         end
       end
     end
 
-    context 'for a client streaming call' do
-      it 'should return the things from the server', run_thing_server: true do
+    context 'when it is a client streaming call' do
+      it 'returns the things from the server', run_thing_server: true do
         things = []
         5.times do
           things << Rpc::Thing.new(
@@ -65,8 +66,9 @@ describe 'Functional server test' do
         expect(resp.message.things.first).to be_a(Rpc::Thing)
       end
     end
-    context 'for a bidi streaming call' do
-      it 'should return the things from the server', run_thing_server: true do
+
+    context 'when it is a bidi streaming call' do
+      it 'returns the things from the server', run_thing_server: true do
         things = []
         5.times do
           things << Rpc::Thing.new(

--- a/spec/gruf/hooks/executor_spec.rb
+++ b/spec/gruf/hooks/executor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -22,14 +24,14 @@ describe Gruf::Hooks::Executor do
   let(:hooks) { [hook1, hook2, hook3] }
   let(:executor) { described_class.new(hooks: hooks) }
 
-  describe '.call' do
+  describe '#call' do
+    subject { executor.call(cmd, arguments) }
+
     let(:cmd) { :before_server_start }
     let(:arguments) { { foo: :bar } }
 
-    subject { executor.call(cmd, arguments) }
-
-    context 'if the hook has the command' do
-      it 'should run the command for each hook' do
+    context 'when the hook has the command' do
+      it 'runs the command for each hook' do
         expect(hook1).to receive(:send).with(cmd, arguments).once
         expect(hook2).to receive(:send).with(cmd, arguments).once
         expect(hook3).to receive(:send).with(cmd, arguments).once
@@ -37,11 +39,11 @@ describe Gruf::Hooks::Executor do
       end
     end
 
-    context 'if the hook does not have the command' do
+    context 'when the hook does not have the command' do
       let(:cmd) { :a_fake_hook_point_that_never_exists }
 
-      it 'should not execute against hooks that do not have it defined' do
-        expect(hook1).to_not receive(:send).with(cmd, arguments)
+      it 'does not execute against hooks that do not have it defined' do
+        expect(hook1).not_to receive(:send).with(cmd, arguments)
         subject
       end
     end
@@ -49,15 +51,15 @@ describe Gruf::Hooks::Executor do
     context 'when some hooks have the method and others do not' do
       let(:cmd) { :after_server_stop }
 
-      it 'should run only against the appropriate hooks' do
+      it 'runs only against the appropriate hooks' do
         expect(hook1).to receive(:send).with(cmd, arguments).once
         expect(hook2).to receive(:send).with(cmd, arguments).once
-        expect(hook3).to_not receive(:send).with(cmd, arguments)
+        expect(hook3).not_to receive(:send).with(cmd, arguments)
         subject
       end
     end
 
-    context 'if the second hook raises an exception' do
+    context 'when the second hook raises an exception' do
       let(:exception) { StandardError.new('Failure') }
 
       before do
@@ -66,7 +68,7 @@ describe Gruf::Hooks::Executor do
 
       it 'the third hook should not execute, but the first should' do
         expect(hook1).to receive(:send).with(cmd, arguments).once
-        expect(hook3).to_not receive(:send).with(cmd, arguments)
+        expect(hook3).not_to receive(:send).with(cmd, arguments)
         expect { subject }.to raise_error(exception)
       end
     end

--- a/spec/gruf/hooks/registry_spec.rb
+++ b/spec/gruf/hooks/registry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -23,10 +25,11 @@ describe Gruf::Hooks::Registry do
   let(:hook_class4) { TestHook4 }
   let(:hook_options) { { one: 'two' } }
 
-  describe '.use' do
+  describe '#use' do
     subject { registry.use(hook_class, hook_options) }
-    it 'should add the hook to the registry' do
-      expect { subject }.to_not raise_error
+
+    it 'adds the hook to the registry' do
+      expect { subject }.not_to raise_error
       expect(registry.count).to eq 1
       expect(registry.instance_variable_get('@registry').first).to eq(
         klass: hook_class,
@@ -35,7 +38,7 @@ describe Gruf::Hooks::Registry do
     end
   end
 
-  describe '.insert_before' do
+  describe '#insert_before' do
     subject { registry.insert_before(hook_class3, hook_class4, hook_options) }
 
     context 'when the before hook exists in the registry' do
@@ -45,7 +48,7 @@ describe Gruf::Hooks::Registry do
         registry.use(hook_class3)
       end
 
-      it 'should insert the hook before it in the registry' do
+      it 'inserts the hook before it in the registry' do
         expect { subject }.not_to raise_error
 
         reg = registry.instance_variable_get('@registry')
@@ -60,13 +63,13 @@ describe Gruf::Hooks::Registry do
         registry.use(hook_class2)
       end
 
-      it 'should raise a HookNotFoundError' do
+      it 'raises a HookNotFoundError' do
         expect { subject }.to raise_error(described_class::HookNotFoundError)
       end
     end
   end
 
-  describe '.insert_after' do
+  describe '#insert_after' do
     subject { registry.insert_after(hook_class2, hook_class3, hook_options) }
 
     context 'when the before hook exists in the registry' do
@@ -76,7 +79,7 @@ describe Gruf::Hooks::Registry do
         registry.use(hook_class4)
       end
 
-      it 'should insert the hook before it in the registry' do
+      it 'inserts the hook before it in the registry' do
         expect { subject }.not_to raise_error
 
         reg = registry.instance_variable_get('@registry')
@@ -91,13 +94,13 @@ describe Gruf::Hooks::Registry do
         registry.use(hook_class4)
       end
 
-      it 'should raise a HookNotFoundError' do
+      it 'raises a HookNotFoundError' do
         expect { subject }.to raise_error(described_class::HookNotFoundError)
       end
     end
   end
 
-  describe '.remove' do
+  describe '#remove' do
     subject { registry.remove(hook_class) }
 
     before do
@@ -105,25 +108,25 @@ describe Gruf::Hooks::Registry do
       registry.use(hook_class3)
     end
 
-    context 'if the hook is in the registry' do
+    context 'when the hook is in the registry' do
       before do
         registry.use(hook_class)
       end
 
-      it 'should remove the hook from the registry' do
+      it 'removes the hook from the registry' do
         expect { subject }.not_to raise_error
         expect(registry.count).to eq 2
       end
     end
 
-    context 'if the hook is not in the registry' do
-      it 'should raise an HookNotFoundError exception' do
+    context 'when the hook is not in the registry' do
+      it 'raises an HookNotFoundError exception' do
         expect { subject }.to raise_error(described_class::HookNotFoundError)
       end
     end
   end
 
-  describe '.clear' do
+  describe '#clear' do
     subject { registry.clear }
 
     before do
@@ -131,17 +134,17 @@ describe Gruf::Hooks::Registry do
       registry.use(hook_class2)
     end
 
-    it 'should clear the registry of hooks' do
+    it 'clears the registry of hooks' do
       expect { subject }.not_to raise_error
       expect(registry.count).to be_zero
     end
   end
 
-  describe '.count' do
+  describe '#count' do
     subject { registry.count }
 
     context 'with no hooks' do
-      it 'should return 0' do
+      it 'returns 0' do
         expect(subject).to be_zero
       end
     end
@@ -151,7 +154,7 @@ describe Gruf::Hooks::Registry do
         registry.use(hook_class)
       end
 
-      it 'should return 1' do
+      it 'returns 1' do
         expect(subject).to eq 1
       end
     end
@@ -163,13 +166,13 @@ describe Gruf::Hooks::Registry do
         registry.use(hook_class3)
       end
 
-      it 'should return the number' do
+      it 'returns the number' do
         expect(subject).to eq 3
       end
     end
   end
 
-  describe '.prepare' do
+  describe '#prepare' do
     subject { registry.prepare }
 
     before do
@@ -178,7 +181,7 @@ describe Gruf::Hooks::Registry do
       registry.use(hook_class2)
     end
 
-    it 'should return all the hooks prepared by the request and maintain insertion order' do
+    it 'returns all the hooks prepared by the request and maintains insertion order' do
       prepped = subject
       expect(prepped.count).to eq 3
       expect(prepped[0]).to be_a(hook_class)

--- a/spec/gruf/interceptors/authentication/basic_spec.rb
+++ b/spec/gruf/interceptors/authentication/basic_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -36,7 +37,7 @@ describe Gruf::Interceptors::Authentication::Basic do
     }
   end
   let(:accepted_credentials) { [server_credentials1, server_credentials2] }
-  let(:request_credentials) { "Basic #{Base64.encode64(prefixed_req_username + request_password)}"}
+  let(:request_credentials) { "Basic #{Base64.encode64(prefixed_req_username + request_password)}" }
 
   let(:excluded_methods) { [] }
 
@@ -44,7 +45,14 @@ describe Gruf::Interceptors::Authentication::Basic do
   let(:active_call) { double(:active_call, metadata: metadata) }
   let(:request) { build :controller_request, active_call: active_call }
   let(:errors) { build :error }
-  let(:interceptor) { described_class.new(request, errors, credentials: accepted_credentials, excluded_methods: excluded_methods) }
+  let(:interceptor) do
+    described_class.new(
+      request,
+      errors,
+      credentials: accepted_credentials,
+      excluded_methods: excluded_methods
+    )
+  end
 
   describe '.valid?' do
     subject { interceptor.call { true } }
@@ -52,41 +60,43 @@ describe Gruf::Interceptors::Authentication::Basic do
     context 'with a server username and password only' do
       let(:accepted_credentials) { [server_credentials1] }
 
-      context 'if the credentials are correct' do
-        it 'should not raise an error' do
-          expect { subject }.to_not raise_error
+      context 'when the credentials are correct' do
+        it 'does not raise an error' do
+          expect { subject }.not_to raise_error
         end
 
-        context 'if excluded_methods is specified' do
-          context 'and the call is in the list' do
+        context 'when excluded_methods is specified' do
+          context 'when the call is in the list' do
             let(:excluded_methods) { ['rpc.thing_service.get_thing'] }
 
-            it 'should allow the request to go through' do
-              expect { subject }.to_not raise_error
+            it 'allows the request to go through' do
+              expect { subject }.not_to raise_error
             end
           end
 
-          context 'and the call is not in the list' do
+          context 'when the call is not in the list' do
             let(:excluded_methods) { ['rpc.thing_service.create_things'] }
 
-            it 'should allow the request to go through' do
-              expect { subject }.to_not raise_error
+            it 'allows the request to go through' do
+              expect { subject }.not_to raise_error
             end
           end
         end
       end
 
-      context 'if the credentials are incorrect' do
-        context 'where the sent user is incorrect' do
+      context 'when the credentials are incorrect' do
+        context 'when the sent user is incorrect' do
           let(:request_username) { 'foo' }
-          it 'should raise a GRPC::Unauthenticated error' do
+
+          it 'raises a GRPC::Unauthenticated error' do
             expect { subject }.to raise_error GRPC::Unauthenticated
           end
         end
 
-        context 'where the sent password is incorrect' do
+        context 'when the sent password is incorrect' do
           let(:request_password) { 'foo' }
-          it 'should raise a GRPC::Unauthenticated error' do
+
+          it 'raises a GRPC::Unauthenticated error' do
             expect { subject }.to raise_error GRPC::Unauthenticated
           end
         end
@@ -94,25 +104,26 @@ describe Gruf::Interceptors::Authentication::Basic do
         context 'when neither are sent' do
           let(:metadata) { {} }
 
-          it 'should raise a GRPC::Unauthenticated error' do
+          it 'raises a GRPC::Unauthenticated error' do
             expect { subject }.to raise_error GRPC::Unauthenticated
           end
         end
 
-        context 'if excluded_methods is specified' do
+        context 'when excluded_methods is specified' do
           let(:request_password) { 'wrong' }
-          context 'and the call is in the list' do
+
+          context 'when the call is in the list' do
             let(:excluded_methods) { ['rpc.thing_service.get_thing'] }
 
-            it 'should allow the request to go through' do
-              expect { subject }.to_not raise_error
+            it 'allows the request to go through' do
+              expect { subject }.not_to raise_error
             end
           end
 
-          context 'and the call is not in the list' do
+          context 'when the call is not in the list' do
             let(:excluded_methods) { ['rpc.thing_service.create_things'] }
 
-            it 'should raise a GRPC::Unauthenticated error' do
+            it 'raises a GRPC::Unauthenticated error' do
               expect { subject }.to raise_error GRPC::Unauthenticated
             end
           end
@@ -125,46 +136,50 @@ describe Gruf::Interceptors::Authentication::Basic do
       let(:request_username) { '' }
       let(:server_username) { '' }
 
-      context 'if the password is correct' do
-        it 'should not raise an error' do
-          expect { subject }.to_not raise_error
+      context 'when the password is correct' do
+        it 'does not raise an error' do
+          expect { subject }.not_to raise_error
         end
       end
 
-      context 'if the password is invalid' do
+      context 'when the password is invalid' do
         let(:request_password) { 'foo' }
-        it 'should raise a GRPC::Unauthenticated error' do
+
+        it 'raises a GRPC::Unauthenticated error' do
           expect { subject }.to raise_error GRPC::Unauthenticated
         end
       end
     end
 
     context 'with a server username and password _or_ only a password' do
-      context 'if the credentials are correct' do
-        it 'should not raise an error' do
-          expect { subject }.to_not raise_error
+      context 'when the credentials are correct' do
+        it 'does not raise an error' do
+          expect { subject }.not_to raise_error
         end
       end
 
-      context 'if the credentials are incorrect' do
-        context 'where the sent user is incorrect' do
+      context 'when the credentials are incorrect' do
+        context 'when the sent user is incorrect' do
           let(:request_username) { 'foo' }
-          it 'should pass on the accepted password' do
-            expect { subject }.to_not raise_error
+
+          it 'passes on the accepted password' do
+            expect { subject }.not_to raise_error
           end
         end
 
-        context 'where the sent password is incorrect' do
+        context 'when the sent password is incorrect' do
           let(:request_password) { 'foo' }
-          it 'should raise a GRPC::Unauthenticated error' do
+
+          it 'raises a GRPC::Unauthenticated error' do
             expect { subject }.to raise_error GRPC::Unauthenticated
           end
         end
 
-        context 'where both the username and password are incorrect' do
+        context 'when both the username and password are incorrect' do
           let(:request_username) { 'foo' }
           let(:request_password) { 'bar' }
-          it 'should raise a GRPC::Unauthenticated error' do
+
+          it 'raises a GRPC::Unauthenticated error' do
             expect { subject }.to raise_error GRPC::Unauthenticated
           end
         end

--- a/spec/gruf/interceptors/client_interceptor_spec.rb
+++ b/spec/gruf/interceptors/client_interceptor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -34,8 +36,8 @@ describe Gruf::Interceptors::ClientInterceptor do
   end
 
   describe 'interception' do
-    context 'for a request_response call' do
-      it 'should route appropriately and yield control' do
+    context 'when it is a request_response call' do
+      it 'routes appropriately and yields control' do
         expect(Gruf.logger).to receive(:info).once
         test = false
         interceptor.request_response(request: requests.first, call: call, method: grpc_method, metadata: metadata) do
@@ -45,8 +47,8 @@ describe Gruf::Interceptors::ClientInterceptor do
       end
     end
 
-    context 'for a client_streamer call' do
-      it 'should route appropriately and yield control' do
+    context 'when it is a client_streamer call' do
+      it 'routes appropriately and yields control' do
         expect(Gruf.logger).to receive(:info).once
         test = false
         interceptor.client_streamer(requests: requests, call: call, method: grpc_method, metadata: metadata) do
@@ -56,8 +58,8 @@ describe Gruf::Interceptors::ClientInterceptor do
       end
     end
 
-    context 'for a server_streamer call' do
-      it 'should route appropriately and yield control' do
+    context 'when it is a server_streamer call' do
+      it 'routes appropriately and yields control' do
         expect(Gruf.logger).to receive(:info).once
         test = false
         interceptor.server_streamer(request: requests.first, call: call, method: grpc_method, metadata: metadata) do
@@ -67,8 +69,8 @@ describe Gruf::Interceptors::ClientInterceptor do
       end
     end
 
-    context 'for a bidi_streamer call' do
-      it 'should route appropriately and yield control' do
+    context 'when it is a bidi_streamer call' do
+      it 'routes appropriately and yields control' do
         expect(Gruf.logger).to receive(:info).once
         test = false
         interceptor.bidi_streamer(requests: requests, call: call, method: grpc_method, metadata: metadata) do
@@ -79,10 +81,10 @@ describe Gruf::Interceptors::ClientInterceptor do
     end
   end
 
-  describe '.call' do
-    let(:interceptor) { Gruf::Interceptors::ClientInterceptor.new }
+  describe '#call' do
+    let(:interceptor) { described_class.new }
 
-    it 'should yield control' do
+    it 'yields control' do
       expect(Gruf.logger).to receive(:debug).once
       expect { |r| interceptor.call(request_context: request_context, &r) }.to yield_control.once
     end

--- a/spec/gruf/interceptors/context_spec.rb
+++ b/spec/gruf/interceptors/context_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -25,9 +26,9 @@ describe Gruf::Interceptors::Context do
   let(:errors) { build :error }
   let(:interceptor_context) { described_class.new(interceptors) }
 
-  describe '.intercept!' do
+  describe '#intercept!' do
     context 'when an interceptor is added' do
-      it 'should execute it and yield the block' do
+      it 'executes it and yields the block' do
         expect_any_instance_of(interceptor_class).to receive(:call).once.and_call_original
 
         expect(Gruf.logger).to receive(:debug).once
@@ -44,7 +45,7 @@ describe Gruf::Interceptors::Context do
         ]
       end
 
-      it 'should execute each in the order it was added' do
+      it 'executes each in the order it was added' do
         expect_any_instance_of(TestServerInterceptor).to receive(:call).once.and_call_original
         expect_any_instance_of(TestServerInterceptor2).to receive(:call).once.and_call_original
         expect_any_instance_of(TestServerInterceptor3).to receive(:call).once.and_call_original

--- a/spec/gruf/interceptors/instrumentation/output_metadata_timer_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/output_metadata_timer_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -22,20 +23,20 @@ describe Gruf::Interceptors::Instrumentation::OutputMetadataTimer do
   let(:errors) { build :error }
   let(:interceptor) { described_class.new(request, errors, options) }
 
-  describe '.call' do
+  describe '#call' do
     subject { interceptor.call { true } }
 
-    it 'should set the execution time to the output metadata' do
-      expect { subject }.to_not raise_error
-      expect(request.active_call.output_metadata[:timer]).to_not be_nil
+    it 'sets the execution time to the output metadata' do
+      expect { subject }.not_to raise_error
+      expect(request.active_call.output_metadata[:timer]).not_to be_nil
     end
 
     context 'with a custom key' do
       let(:options) { { metadata_key: :foo } }
 
-      it 'should set the execution time to the output metadata with the new key' do
-        expect { subject }.to_not raise_error
-        expect(request.active_call.output_metadata[:foo]).to_not be_nil
+      it 'sets the execution time to the output metadata with the new key' do
+        expect { subject }.not_to raise_error
+        expect(request.active_call.output_metadata[:foo]).not_to be_nil
       end
     end
   end

--- a/spec/gruf/interceptors/instrumentation/request_logging/formatters/base_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/formatters/base_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -22,10 +23,10 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Formatters::Base d
   let(:result) { Gruf::Interceptors::Timer.time { Rpc::GetThingResponse.new } }
   let(:payload) { {} }
 
-  describe '.format' do
+  describe '#format' do
     subject { formatter.format(payload, request: request, result: result) }
 
-    it 'should raise a NotImplementedError' do
+    it 'raises a NotImplementedError' do
       expect { subject }.to raise_error(NotImplementedError)
     end
   end

--- a/spec/gruf/interceptors/instrumentation/request_logging/formatters/logstash_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/formatters/logstash_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -20,12 +21,12 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Formatters::Logsta
   let(:formatter) { described_class.new }
   let(:request) { build :controller_request }
   let(:result) { Gruf::Interceptors::Timer.time { Rpc::GetThingResponse.new } }
-  let(:payload) { { message: 'foo', params: {one: 2} } }
+  let(:payload) { { message: 'foo', params: { one: 2 } } }
 
-  describe '.format' do
+  describe '#format' do
     subject { formatter.format(payload, request: request, result: result) }
 
-    it 'should return the payload as a JSON object' do
+    it 'returns the payload as a JSON object' do
       expect(subject).to eq payload.merge(format: 'json').to_json
     end
   end

--- a/spec/gruf/interceptors/instrumentation/request_logging/formatters/plain_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/formatters/plain_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -27,19 +28,21 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Formatters::Plain 
   let(:result) { Gruf::Interceptors::Timer.time { Rpc::GetThingResponse.new } }
   let(:payload) { { message: message, status: status, method: route_key, duration: execution_time, params: params } }
 
-  describe '.format' do
+  describe '#format' do
     subject { formatter.format(payload, request: request, result: result) }
 
     context 'when params are sent to the formatter' do
-      it 'should return the message, without params' do
-        expect(subject).to eq "[#{status}] (#{route_key}) [#{execution_time}ms] #{message} Parameters: #{params.to_h}".strip
+      it 'returns the message, without params' do
+        expect(subject).to eq(
+          "[#{status}] (#{route_key}) [#{execution_time}ms] #{message} Parameters: #{params.to_h}".strip
+        )
       end
     end
 
     context 'when params are not sent to the formatter' do
       let(:payload) { super().except(:params) }
 
-      it 'should return the message' do
+      it 'returns the message' do
         expect(subject).to eq "[#{status}] (#{route_key}) [#{execution_time}ms] #{message}".strip
       end
     end

--- a/spec/gruf/interceptors/instrumentation/statsd_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/statsd_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -27,11 +28,11 @@ describe Gruf::Interceptors::Instrumentation::Statsd do
 
   let(:expected_route_key) { "#{prefix ? "#{prefix}." : ''}rpc.thing_service.get_thing" }
 
-  describe '.call' do
+  describe '#call' do
     subject { interceptor.call { true } }
 
     context 'with a valid client' do
-      it 'should send the metrics to statsd' do
+      it 'sends the metrics to statsd' do
         expect(client).to receive(:increment).with(expected_route_key).once
         expect(client).to receive(:timing).with(expected_route_key, kind_of(Float)).once
         subject
@@ -41,7 +42,7 @@ describe Gruf::Interceptors::Instrumentation::Statsd do
     context 'with no client specified' do
       let(:options) { {} }
 
-      it 'should noop and log an error' do
+      it 'no-ops and logs an error' do
         expect(Gruf.logger).to receive(:error)
         subject
       end
@@ -51,15 +52,16 @@ describe Gruf::Interceptors::Instrumentation::Statsd do
   describe '.key_prefix' do
     subject { interceptor.send(:key_prefix) }
 
-    context 'if a prefix is specified' do
-      it 'should postfix a dot to it' do
+    context 'when a prefix is specified' do
+      it 'postfixes a dot to it' do
         expect(subject).to eq "#{prefix}."
       end
     end
 
-    context 'if no prefix is specified' do
+    context 'when no prefix is specified' do
       let(:prefix) { '' }
-      it 'should return an empty string' do
+
+      it 'returns an empty string' do
         expect(subject).to eq ''
       end
     end
@@ -68,7 +70,7 @@ describe Gruf::Interceptors::Instrumentation::Statsd do
   describe '.route_key' do
     subject { interceptor.send(:route_key) }
 
-    it 'should build the proper route key based on the prefix, service, and call signature' do
+    it 'builds the proper route key based on the prefix, service, and call signature' do
       expect(subject).to eq expected_route_key
     end
   end
@@ -76,16 +78,16 @@ describe Gruf::Interceptors::Instrumentation::Statsd do
   describe '.client' do
     subject { interceptor.send(:client) }
 
-    context 'if a client is specified' do
-      it 'should return it' do
+    context 'when a client is specified' do
+      it 'returns it' do
         expect(subject).to eq client
       end
     end
 
-    context 'if no client is specified' do
+    context 'when no client is specified' do
       let(:client) { nil }
 
-      it 'should return nil' do
+      it 'returns nil' do
         expect(subject).to be_nil
       end
     end

--- a/spec/gruf/interceptors/registry_spec.rb
+++ b/spec/gruf/interceptors/registry_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -23,10 +25,11 @@ describe Gruf::Interceptors::Registry do
   let(:interceptor_class4) { TestServerInterceptor4 }
   let(:interceptor_options) { { one: 'two' } }
 
-  describe '.use' do
+  describe '#use' do
     subject { registry.use(interceptor_class, interceptor_options) }
-    it 'should add the interceptor to the registry' do
-      expect { subject }.to_not raise_error
+
+    it 'adds the interceptor to the registry' do
+      expect { subject }.not_to raise_error
       expect(registry.count).to eq 1
       expect(registry.instance_variable_get('@registry').first).to eq(
         klass: interceptor_class,
@@ -35,7 +38,7 @@ describe Gruf::Interceptors::Registry do
     end
   end
 
-  describe '.insert_before' do
+  describe '#insert_before' do
     subject { registry.insert_before(interceptor_class3, interceptor_class4, interceptor_options) }
 
     context 'when the before interceptor exists in the registry' do
@@ -45,7 +48,7 @@ describe Gruf::Interceptors::Registry do
         registry.use(interceptor_class3)
       end
 
-      it 'should insert the interceptor before it in the registry' do
+      it 'inserts the interceptor before it in the registry' do
         expect { subject }.not_to raise_error
 
         reg = registry.instance_variable_get('@registry')
@@ -60,13 +63,13 @@ describe Gruf::Interceptors::Registry do
         registry.use(interceptor_class2)
       end
 
-      it 'should raise a InterceptorNotFoundError' do
+      it 'raises a InterceptorNotFoundError' do
         expect { subject }.to raise_error(described_class::InterceptorNotFoundError)
       end
     end
   end
 
-  describe '.insert_after' do
+  describe '#insert_after' do
     subject { registry.insert_after(interceptor_class2, interceptor_class3, interceptor_options) }
 
     context 'when the before interceptor exists in the registry' do
@@ -76,7 +79,7 @@ describe Gruf::Interceptors::Registry do
         registry.use(interceptor_class4)
       end
 
-      it 'should insert the interceptor before it in the registry' do
+      it 'inserts the interceptor before it in the registry' do
         expect { subject }.not_to raise_error
 
         reg = registry.instance_variable_get('@registry')
@@ -91,13 +94,13 @@ describe Gruf::Interceptors::Registry do
         registry.use(interceptor_class4)
       end
 
-      it 'should raise a InterceptorNotFoundError' do
+      it 'raises an InterceptorNotFoundError' do
         expect { subject }.to raise_error(described_class::InterceptorNotFoundError)
       end
     end
   end
 
-  describe '.remove' do
+  describe '#remove' do
     subject { registry.remove(interceptor_class) }
 
     before do
@@ -105,25 +108,25 @@ describe Gruf::Interceptors::Registry do
       registry.use(interceptor_class3)
     end
 
-    context 'if the interceptor is in the registry' do
+    context 'when the interceptor is in the registry' do
       before do
         registry.use(interceptor_class)
       end
 
-      it 'should remove the interceptor from the registry' do
+      it 'removes the interceptor from the registry' do
         expect { subject }.not_to raise_error
         expect(registry.count).to eq 2
       end
     end
 
-    context 'if the interceptor is not in the registry' do
-      it 'should raise an InterceptorNotFoundError exception' do
+    context 'when the interceptor is not in the registry' do
+      it 'raises an InterceptorNotFoundError' do
         expect { subject }.to raise_error(described_class::InterceptorNotFoundError)
       end
     end
   end
 
-  describe '.clear' do
+  describe '#clear' do
     subject { registry.clear }
 
     before do
@@ -131,17 +134,17 @@ describe Gruf::Interceptors::Registry do
       registry.use(interceptor_class2)
     end
 
-    it 'should clear the registry of interceptors' do
+    it 'clears the registry of interceptors' do
       expect { subject }.not_to raise_error
       expect(registry.count).to be_zero
     end
   end
 
-  describe '.count' do
+  describe '#count' do
     subject { registry.count }
 
     context 'with no interceptors' do
-      it 'should return 0' do
+      it 'returns 0' do
         expect(subject).to be_zero
       end
     end
@@ -151,7 +154,7 @@ describe Gruf::Interceptors::Registry do
         registry.use(interceptor_class)
       end
 
-      it 'should return 1' do
+      it 'returns 1' do
         expect(subject).to eq 1
       end
     end
@@ -163,16 +166,17 @@ describe Gruf::Interceptors::Registry do
         registry.use(interceptor_class3)
       end
 
-      it 'should return the number' do
+      it 'returns the number' do
         expect(subject).to eq 3
       end
     end
   end
 
-  describe '.prepare' do
+  describe '#prepare' do
+    subject { registry.prepare(request, errors) }
+
     let(:request) { build :controller_request }
     let(:errors) { build :error }
-    subject { registry.prepare(request, errors) }
 
     before do
       registry.use(interceptor_class)
@@ -180,7 +184,7 @@ describe Gruf::Interceptors::Registry do
       registry.use(interceptor_class2)
     end
 
-    it 'should return all the interceptors prepared by the request and maintain insertion order' do
+    it 'returns all the interceptors prepared by the request and maintains insertion order' do
       prepped = subject
       expect(prepped.count).to eq 3
       expect(prepped[0]).to be_a(interceptor_class)

--- a/spec/gruf/interceptors/server_interceptor_spec.rb
+++ b/spec/gruf/interceptors/server_interceptor_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -24,7 +25,7 @@ describe Gruf::Interceptors::ServerInterceptor do
   describe 'statelessness' do
     let(:interceptor) { TestServerInterceptorInstanceVar }
 
-    it 'should not persist interceptor instance variables across requests', run_thing_server: true do
+    it 'does not persist interceptor instance variables across requests', run_thing_server: true do
       client = build_client
       resp = client.call(:GetThing)
       expect(resp.message).to be_a(Rpc::GetThingResponse)
@@ -33,15 +34,16 @@ describe Gruf::Interceptors::ServerInterceptor do
     end
   end
 
-  describe '.call' do
-    let(:request) { build :controller_request }
-    let(:error) { build :error }
+  describe '#call' do
     subject { interceptor.new(request, error, {}).call }
 
-    context 'if it is not extended' do
-      let(:interceptor) { Gruf::Interceptors::ServerInterceptor }
+    let(:request) { build :controller_request }
+    let(:error) { build :error }
 
-      it 'should raise a NotImplementedError' do
+    context 'when it is not extended' do
+      let(:interceptor) { described_class }
+
+      it 'raises a NotImplementedError' do
         expect { subject }.to raise_error(NotImplementedError)
       end
     end

--- a/spec/gruf/interceptors/timer_spec.rb
+++ b/spec/gruf/interceptors/timer_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -19,27 +20,29 @@ require 'spec_helper'
 describe Gruf::Interceptors::Timer do
   describe '#time' do
     context 'when the result does not throw a GRPC::BadStatus exception' do
-      let(:message) { Rpc::GetThingResponse.new }
       subject { described_class.time { message } }
 
-      it 'should return a successful result' do
+      let(:message) { Rpc::GetThingResponse.new }
+
+      it 'returns a successful result' do
         expect(subject).to be_a(described_class::Result)
-        expect(subject.successful?).to be_truthy
+        expect(subject).to be_successful
         expect(subject.message).to eq message
-        expect(subject.elapsed).to_not be_zero
+        expect(subject.elapsed).not_to be_zero
       end
     end
 
     context 'when the result does throw a GRPC::BadStatus exception' do
-      let(:error_message) { FFaker::Lorem.sentence }
-      let(:error) { GRPC::NotFound.new(error_message) }
       subject { described_class.time { raise error } }
 
-      it 'should return an unsuccessful result' do
+      let(:error_message) { FFaker::Lorem.sentence }
+      let(:error) { GRPC::NotFound.new(error_message) }
+
+      it 'returns an unsuccessful result' do
         expect(subject).to be_a(described_class::Result)
-        expect(subject.successful?).to be_falsey
+        expect(subject).not_to be_successful
         expect(subject.message).to eq error
-        expect(subject.elapsed).to_not be_zero
+        expect(subject.elapsed).not_to be_zero
       end
     end
   end
@@ -49,27 +52,27 @@ describe Gruf::Interceptors::Timer do
       let(:message) { Rpc::GetThingResponse.new }
       let(:result) { Gruf::Interceptors::Timer.time { message } }
 
-      describe '.successful?' do
+      describe '#successful?' do
         subject { result.successful? }
 
-        it 'should return true' do
+        it 'returns true' do
           expect(subject).to be_truthy
         end
       end
 
-      describe '.message_class_name' do
+      describe '#message_class_name' do
         subject { result.message_class_name }
 
-        it 'should return the name of the message class' do
+        it 'returns the name of the message class' do
           expect(subject).to eq message.class.name
         end
       end
 
-      describe '.elapsed_rounded' do
+      describe '#elapsed_rounded' do
         let(:precision) { 2 }
         let(:subject) { result.elapsed_rounded(precision: precision) }
 
-        it 'should round the elapsed time' do
+        it 'rounds the elapsed time' do
           expect(subject).to eq result.elapsed.round(precision)
         end
       end
@@ -80,10 +83,10 @@ describe Gruf::Interceptors::Timer do
       let(:error) { GRPC::NotFound.new(error_message) }
       let(:result) { Gruf::Interceptors::Timer.time { raise error } }
 
-      describe '.successful?' do
+      describe '#successful?' do
         subject { result.successful? }
 
-        it 'should return false' do
+        it 'returns false' do
           expect(subject).to be_falsey
         end
       end

--- a/spec/gruf/loggable_spec.rb
+++ b/spec/gruf/loggable_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -21,10 +22,11 @@ class TestLoggable
 end
 
 describe Gruf::Loggable do
-  let(:cls) { TestLoggable.new }
   subject { cls.logger }
 
-  it 'should add a logger method when included' do
+  let(:cls) { TestLoggable.new }
+
+  it 'adds a logger method when included' do
     expect(subject).to eq Gruf.logger
   end
 end

--- a/spec/gruf/logging_spec.rb
+++ b/spec/gruf/logging_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -23,20 +24,24 @@ class TestGrpcLogging
   include Gruf::GrpcLogger
 end
 
-describe Gruf::Logger do
-  let(:cls) { TestLogging.new }
-  subject { cls.logger }
+describe 'Loggers' do
+  describe Gruf::Logger do
+    subject { cls.logger }
 
-  it 'should add a logger method when included' do
-    expect(subject).to eq Gruf.logger
+    let(:cls) { TestLogging.new }
+
+    it 'adds a logger method when included' do
+      expect(subject).to eq Gruf.logger
+    end
   end
-end
 
-describe Gruf::GrpcLogger do
-  let(:cls) { TestGrpcLogging.new }
-  subject { cls.logger }
+  describe Gruf::GrpcLogger do
+    subject { cls.logger }
 
-  it 'should add a logger method when included' do
-    expect(subject).to eq Gruf.grpc_logger
+    let(:cls) { TestGrpcLogging.new }
+
+    it 'adds a logger method when included' do
+      expect(subject).to eq Gruf.grpc_logger
+    end
   end
 end

--- a/spec/gruf/outbound/request_context_spec.rb
+++ b/spec/gruf/outbound/request_context_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -31,19 +33,18 @@ describe Gruf::Outbound::RequestContext do
     )
   end
 
-  describe '.method_name' do
+  describe '#method_name' do
     subject { request_context.method_name }
 
-    it 'should parse out the method name' do
+    it 'parses out the method name' do
       expect(subject).to eq 'GetThing'
     end
-
   end
 
-  describe '.route_key' do
+  describe '#route_key' do
     subject { request_context.route_key }
 
-    it 'should return a friendly routing key' do
+    it 'returns a friendly routing key' do
       expect(subject).to eq 'rpc.thing_service.get_thing'
     end
   end

--- a/spec/gruf/response_spec.rb
+++ b/spec/gruf/response_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -27,7 +28,7 @@ describe Gruf::Response do
   describe '.initialize' do
     subject { response }
 
-    it 'should setup the appropriate values' do
+    it 'sets up the appropriate values' do
       expect(subject).to be_a(described_class)
       expect(subject.operation).to eq operation
       expect(subject.message).to eq message
@@ -38,33 +39,33 @@ describe Gruf::Response do
     end
 
     context 'with no specified execution time' do
-      it 'should set the execution time to 0.0' do
+      it 'sets the execution time to 0.0' do
         expect(subject.execution_time).to eq 0.0
       end
     end
 
-    context 'with no specified execution time' do
+    context 'with a specified execution time' do
       let(:execution_time) { rand(1.00..200.00) }
 
-      it 'should set it to the passed value' do
+      it 'sets it to the passed value' do
         expect(subject.execution_time).to eq execution_time
       end
     end
   end
 
-  describe '.message' do
+  describe '#message' do
     subject { response.message }
 
-    it 'should return the operation execution result' do
+    it 'returns the operation execution result' do
       expect(subject).to eq message
     end
   end
 
-  describe '.internal_execution_time' do
+  describe '#internal_execution_time' do
     subject { response.internal_execution_time }
 
     context 'when the time is passed through the trailing metadata' do
-      it 'should return that time' do
+      it 'returns that time' do
         expect(subject).to eq internal_execution_time
       end
     end
@@ -72,7 +73,7 @@ describe Gruf::Response do
     context 'when no time is passed' do
       let(:trailing_metadata) { {} }
 
-      it 'it should return 0.0' do
+      it 'returns 0.0' do
         expect(subject).to eq 0.0
       end
     end

--- a/spec/gruf/serializers/errors/base_spec.rb
+++ b/spec/gruf/serializers/errors/base_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -23,7 +24,7 @@ describe Gruf::Serializers::Errors::Base do
   describe '.initialize' do
     subject { serializer }
 
-    it 'should set the error on the object' do
+    it 'sets the error on the object' do
       expect(subject.error).to eq error
     end
   end
@@ -34,7 +35,7 @@ describe Gruf::Serializers::Errors::Base do
     describe '.serialize' do
       subject { serializer.serialize }
 
-      it 'should raise NotImplementedError' do
+      it 'raises NotImplementedError' do
         expect { subject }.to raise_error NotImplementedError
       end
     end
@@ -42,7 +43,7 @@ describe Gruf::Serializers::Errors::Base do
     describe '.deserialize' do
       subject { serializer.deserialize }
 
-      it 'should raise NotImplementedError' do
+      it 'raises NotImplementedError' do
         expect { subject }.to raise_error NotImplementedError
       end
     end

--- a/spec/gruf/server_spec.rb
+++ b/spec/gruf/server_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -17,9 +18,10 @@
 require 'spec_helper'
 
 describe Gruf::Server do
+  subject { gruf_server }
+
   let(:options) { {} }
   let(:gruf_server) { described_class.new(options) }
-  subject { gruf_server }
 
   shared_context 'with stop thread mocked' do
     let(:thread_mock) { double(Thread, join: nil) }
@@ -38,7 +40,8 @@ describe Gruf::Server do
       let(:options) { { pool_size: Random.rand(10) } }
 
       it 'runs server with given overrides' do
-        expect(GRPC::RpcServer).to receive(:new).with(Gruf.rpc_server_options.merge(options)).and_return(server_mock)
+        expect(GRPC::RpcServer).to receive(:new)
+          .with(Gruf.rpc_server_options.merge(options)).and_return(server_mock)
         gruf_server.start!
       end
     end
@@ -49,7 +52,8 @@ describe Gruf::Server do
       let(:options) { { random_option: Random.rand(10) } }
 
       it 'runs server with default configuration' do
-        expect(GRPC::RpcServer).to receive(:new).with(Gruf.rpc_server_options).and_return(server_mock)
+        expect(GRPC::RpcServer).to receive(:new)
+          .with(Gruf.rpc_server_options).and_return(server_mock)
         gruf_server.start!
       end
     end
@@ -61,7 +65,8 @@ describe Gruf::Server do
 
       it 'runs server with valid overrides only' do
         valid_options = { pool_size: options[:pool_size] }
-        expect(GRPC::RpcServer).to receive(:new).with(Gruf.rpc_server_options.merge(valid_options)).and_return(server_mock)
+        expect(GRPC::RpcServer).to receive(:new)
+          .with(Gruf.rpc_server_options.merge(valid_options)).and_return(server_mock)
         gruf_server.start!
       end
     end
@@ -70,7 +75,8 @@ describe Gruf::Server do
       include_context 'with stop thread mocked'
 
       it 'runs server with default configuration' do
-        expect(GRPC::RpcServer).to receive(:new).with(Gruf.rpc_server_options).and_return(server_mock)
+        expect(GRPC::RpcServer).to receive(:new)
+          .with(Gruf.rpc_server_options).and_return(server_mock)
         gruf_server.start!
       end
     end
@@ -90,45 +96,47 @@ describe Gruf::Server do
     end
   end
 
-  describe '.add_service' do
-    let(:service) { Rpc::ThingService }
+  describe '#add_service' do
     subject { gruf_server.add_service(service) }
 
-    context 'if the service is not yet in the registry' do
-      it 'should add a service to the registry' do
+    let(:service) { Rpc::ThingService }
+
+    context 'when the service is not yet in the registry' do
+      it 'adds a service to the registry' do
         expect { subject }.to(change { gruf_server.instance_variable_get('@services').count }.by(1))
         expect(gruf_server.instance_variable_get('@services')).to eq [service]
       end
     end
 
-    context 'if the service is already in the registry' do
-      it 'should not add the service' do
+    context 'when the service is already in the registry' do
+      it 'does not add the service' do
         gruf_server.add_service(service)
-        expect { subject }.to_not(change { gruf_server.instance_variable_get('@services').count })
+        expect { subject }.not_to(change { gruf_server.instance_variable_get('@services').count })
       end
     end
 
-    context 'if the server is already started' do
+    context 'when the server is already started' do
       before do
         gruf_server.instance_variable_set(:@started, true)
       end
 
-      it 'should raise a ServerAlreadyStartedError exception' do
+      it 'raises ServerAlreadyStartedError' do
         expect { subject }.to raise_error(Gruf::Server::ServerAlreadyStartedError)
       end
     end
   end
 
-  describe '.add_interceptor' do
+  describe '#add_interceptor' do
+    subject { gruf_server.add_interceptor(interceptor_class, interceptor_options) }
+
     let(:interceptor_class) { TestServerInterceptor }
     let(:interceptor_options) { { foo: 'bar' } }
-    subject { gruf_server.add_interceptor(interceptor_class, interceptor_options) }
 
     before do
       Gruf.interceptors.clear
     end
 
-    it 'should add the interceptor to the registry' do
+    it 'adds the interceptor to the registry' do
       expect { subject }.to(change { gruf_server.instance_variable_get('@interceptors').count }.by(1))
       is = gruf_server.instance_variable_get('@interceptors').prepare(nil, nil)
       i = is.first
@@ -136,64 +144,65 @@ describe Gruf::Server do
       expect(i.options).to eq interceptor_options
     end
 
-    context 'if the server is already started' do
+    context 'when the server is already started' do
       before do
         gruf_server.instance_variable_set(:@started, true)
       end
 
-      it 'should raise a ServerAlreadyStartedError exception' do
+      it 'raises ServerAlreadyStartedError' do
         expect { subject }.to raise_error(Gruf::Server::ServerAlreadyStartedError)
       end
     end
   end
 
-  describe '.list_interceptors' do
-    let(:interceptor) { TestServerInterceptor }
+  describe '#list_interceptors' do
     subject { gruf_server.list_interceptors }
+
+    let(:interceptor) { TestServerInterceptor }
 
     before do
       Gruf.interceptors.clear
       gruf_server.add_interceptor(interceptor)
     end
 
-    it 'should return the current list of interceptors' do
+    it 'returns the current list of interceptors' do
       expect(subject).to eq [interceptor]
     end
   end
 
-  describe '.insert_interceptor_before' do
+  describe '#insert_interceptor_before' do
+    subject { gruf_server.insert_interceptor_before(interceptor, interceptor2) }
+
     let(:interceptor) { TestServerInterceptor }
     let(:interceptor2) { TestServerInterceptor2 }
-
-    subject { gruf_server.insert_interceptor_before(interceptor, interceptor2) }
 
     before do
       Gruf.interceptors.clear
       gruf_server.add_interceptor(interceptor)
     end
 
-    it 'should add the new interceptor before the targeted one' do
-      expect { subject }.to_not raise_error
+    it 'adds the new interceptor before the targeted one' do
+      expect { subject }.not_to raise_error
       expect(gruf_server.list_interceptors).to eq [interceptor2, interceptor]
     end
 
-    context 'if the server is already started' do
+    context 'when the server is already started' do
       before do
         gruf_server.instance_variable_set(:@started, true)
       end
 
-      it 'should raise a ServerAlreadyStartedError exception' do
+      it 'raises ServerAlreadyStartedError' do
         expect { subject }.to raise_error(Gruf::Server::ServerAlreadyStartedError)
       end
     end
   end
 
-  describe '.insert_interceptor_after' do
+  describe '#insert_interceptor_after' do
+    subject { gruf_server.insert_interceptor_after(interceptor, interceptor3) }
+
     let(:interceptor) { TestServerInterceptor }
     let(:interceptor2) { TestServerInterceptor2 }
     let(:interceptor3) { TestServerInterceptor3 }
-
-    subject { gruf_server.insert_interceptor_after(interceptor, interceptor3) }
 
     before do
       Gruf.interceptors.clear
@@ -201,27 +210,28 @@ describe Gruf::Server do
       gruf_server.add_interceptor(interceptor2)
     end
 
-    it 'should add the new interceptor after the targeted one' do
-      expect { subject }.to_not raise_error
+    it 'adds the new interceptor after the targeted one' do
+      expect { subject }.not_to raise_error
       expect(gruf_server.list_interceptors).to eq [interceptor, interceptor3, interceptor2]
     end
 
-    context 'if the server is already started' do
+    context 'when the server is already started' do
       before do
         gruf_server.instance_variable_set(:@started, true)
       end
 
-      it 'should raise a ServerAlreadyStartedError exception' do
+      it 'raises ServerAlreadyStartedError' do
         expect { subject }.to raise_error(Gruf::Server::ServerAlreadyStartedError)
       end
     end
   end
 
-  describe '.remove_interceptor' do
+  describe '#remove_interceptor' do
+    subject { gruf_server.remove_interceptor(interceptor) }
+
     let(:interceptor) { TestServerInterceptor }
     let(:interceptor2) { TestServerInterceptor2 }
     let(:interceptor3) { TestServerInterceptor3 }
-    subject { gruf_server.remove_interceptor(interceptor) }
 
     before do
       Gruf.interceptors.clear
@@ -234,49 +244,50 @@ describe Gruf::Server do
         gruf_server.add_interceptor(interceptor)
       end
 
-      it 'should remove the interceptor from the registry' do
-        expect { subject }.to_not raise_error
+      it 'removes the interceptor from the registry' do
+        expect { subject }.not_to raise_error
         expect(gruf_server.list_interceptors.count).to eq 2
       end
     end
 
     context 'when the interceptor is not in the registry' do
-      it 'should raise a InterceptorNotFoundError exception' do
+      it 'raises InterceptorNotFoundError' do
         expect { subject }.to raise_error(Gruf::Interceptors::Registry::InterceptorNotFoundError)
       end
     end
 
-    context 'if the server is already started' do
+    context 'when the server is already started' do
       before do
         gruf_server.instance_variable_set(:@started, true)
       end
 
-      it 'should raise a ServerAlreadyStartedError exception' do
+      it 'raises ServerAlreadyStartedError' do
         expect { subject }.to raise_error(Gruf::Server::ServerAlreadyStartedError)
       end
     end
   end
 
-  describe '.clear_interceptors' do
-    let(:interceptor) { TestServerInterceptor }
+  describe '#clear_interceptors' do
     subject { gruf_server.clear_interceptors }
+
+    let(:interceptor) { TestServerInterceptor }
 
     before do
       Gruf.interceptors.clear
       gruf_server.add_interceptor(interceptor)
     end
 
-    it 'should clear all interceptors from the registry' do
-      expect { subject }.to_not raise_error
+    it 'clears all interceptors from the registry' do
+      expect { subject }.not_to raise_error
       expect(gruf_server.list_interceptors).to eq []
     end
 
-    context 'if the server is already started' do
+    context 'when the server is already started' do
       before do
         gruf_server.instance_variable_set(:@started, true)
       end
 
-      it 'should raise a ServerAlreadyStartedError exception' do
+      it 'raises ServerAlreadyStartedError' do
         expect { subject }.to raise_error(Gruf::Server::ServerAlreadyStartedError)
       end
     end

--- a/spec/gruf/timer_spec.rb
+++ b/spec/gruf/timer_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -17,14 +18,13 @@
 require 'spec_helper'
 
 describe Gruf::Timer do
-
   describe '#time' do
     let(:result) { { foo: 'bar' } }
 
     context 'when the operation yields normally' do
       subject { described_class.time { result } }
 
-      it 'should return a timed result with the proper values' do
+      it 'returns a timed result with the proper values' do
         expect(subject).to be_a(Gruf::Timer::Result)
         expect(subject.result).to eq result
         expect(subject.time).to be > 0.00
@@ -34,29 +34,30 @@ describe Gruf::Timer do
     context 'when the operation raises an error' do
       subject { described_class.time { raise err } }
 
-      context 'that is a BadStatus exception' do
+      context 'when that is a BadStatus exception' do
         let(:err) { GRPC::Internal.new('ack!') }
 
-        it 'should return the BadStatus as the result with a time' do
+        it 'returns the BadStatus as the result with a time' do
           expect(subject).to be_a(Gruf::Timer::Result)
           expect(subject.result).to eq err
           expect(subject.time).to be > 0.00
         end
       end
-      context 'that is a GRPC::Core::CallError' do
+
+      context 'when that is a GRPC::Core::CallError' do
         let(:err) { GRPC::Core::CallError.new('really bad things') }
 
-        it 'should return it as the result with a time' do
+        it 'returns it as the result with a time' do
           expect(subject).to be_a(Gruf::Timer::Result)
           expect(subject.result).to eq err
           expect(subject.time).to be > 0.00
         end
       end
 
-      context 'that is any other exception' do
+      context 'when that is any other exception' do
         let(:err) { StandardError.new("it's a trap!") }
 
-        it 'should return it as the result with a time' do
+        it 'returns it as the result with a time' do
           expect(subject).to be_a(Gruf::Timer::Result)
           expect(subject.result).to eq err
           expect(subject.time).to be > 0.00
@@ -64,37 +65,37 @@ describe Gruf::Timer do
       end
     end
   end
-end
 
-describe Gruf::Timer::Result do
-  let(:time) { rand(10.00..500.00) }
-  let(:result) { {} }
-  let(:timed_result) { described_class.new(result, time) }
+  describe Gruf::Timer::Result do
+    let(:time) { rand(10.00..500.00).to_f }
+    let(:result) { {} }
+    let(:timed_result) { described_class.new(result, time) }
 
-  describe '.initialize' do
-    subject { timed_result }
+    describe '#initialize' do
+      subject { timed_result }
 
-    it 'should setup and cast the values appropriately' do
-      expect(subject).to be_a described_class
-      expect(subject.time).to eq time
-      expect(subject.result).to eq result
-    end
-  end
-
-  describe '.success?' do
-    subject { timed_result.success? }
-
-    context 'with a normal result' do
-      it 'should return true' do
-        expect(subject).to be_truthy
+      it 'sets up and casts the values appropriately' do
+        expect(subject).to be_a described_class
+        expect(subject.time).to eq time
+        expect(subject.result).to eq result
       end
     end
 
-    context 'with a BadStatus result' do
-      let(:result) { GRPC::BadStatus.new(5, 'Boo', foo: 'bar') }
+    describe '.success?' do
+      subject { timed_result.success? }
 
-      it 'should return false' do
-        expect(subject).to be_falsey
+      context 'with a normal result' do
+        it 'returns true' do
+          expect(subject).to be_truthy
+        end
+      end
+
+      context 'with a BadStatus result' do
+        let(:result) { GRPC::BadStatus.new(5, 'Boo', foo: 'bar') }
+
+        it 'returns false' do
+          expect(subject).to be_falsey
+        end
       end
     end
   end

--- a/spec/gruf/version_spec.rb
+++ b/spec/gruf/version_spec.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -16,8 +17,8 @@
 #
 require 'spec_helper'
 
-describe Gruf::VERSION do
-  it 'should have a version' do
-    expect(Gruf::VERSION).to_not be_nil
+describe Gruf do
+  it 'has a version' do
+    expect(described_class::VERSION).not_to be_nil
   end
 end

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -14,30 +15,24 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-$LOAD_PATH.unshift File.expand_path('../pb', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+$LOAD_PATH.unshift File.expand_path('pb', __dir__)
 require_relative 'simplecov_helper'
 require 'gruf'
 require 'ffaker'
 require 'pry'
-require 'null_logger'
 
-Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].each {|f| require f }
+Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
-  config.alias_example_to :fit, focus: true
-  config.filter_run focus: true
-  config.filter_run_excluding broken: true
-  config.run_all_when_everything_filtered = true
-  config.expose_current_running_example_as :example
   config.mock_with :rspec do |mocks|
     mocks.allow_message_expectations_on_nil = true
   end
   config.color = true
 
   config.before do
-    Gruf.logger = NullLogger.new unless ENV.fetch('GRUF_DEBUG', false)
-    Gruf.grpc_logger = NullLogger.new unless ENV.fetch('GRPC_DEBUG', false)
+    Gruf.logger = Logger.new(File::NULL) unless ENV.fetch('GRUF_DEBUG', false)
+    Gruf.grpc_logger = Logger.new(File::NULL) unless ENV.fetch('GRPC_DEBUG', false)
   end
   config.around(:example, run_thing_server: true) do |t|
     @server = build_server

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/spec/support/grpc.rb
+++ b/spec/support/grpc.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -46,8 +46,8 @@ module Gruf
         c.server_binding_url = HOST
         c.default_client_host = HOST
         c.use_default_interceptors = false
-        c.logger = NullLogger.new unless ENV.fetch('GRUF_DEBUG', false)
-        c.grpc_logger = NullLogger.new unless ENV.fetch('GRPC_DEBUG', false)
+        c.logger = ::Logger.new(File::NULL) unless ENV.fetch('GRUF_DEBUG', false)
+        c.grpc_logger = ::Logger.new(File::NULL) unless ENV.fetch('GRPC_DEBUG', false)
       end
       s = Gruf::Server.new(poll_period: 1)
       is.each do |k, opts|

--- a/spec/support/hooks.rb
+++ b/spec/support/hooks.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/spec/support/interceptors.rb
+++ b/spec/support/interceptors.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/spec/support/serializers/proto.rb
+++ b/spec/support/serializers/proto.rb
@@ -1,4 +1,5 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated


### PR DESCRIPTION
## What? Why?

Some gardening to clean up the spec suite, and get Gruf generally adherent to Rubocop 1.4.

- Updates to Rubocop 1.4
- Adds in `frozen_string_literal: true` to all spec files
- Add in rubocop-rspec for rubocop coverage of spec tests

Most of this is the string literal addition and converting `should` to active tense. It does not add or remove any functionality from gruf itself.

## How was it tested?

rspec, this PR.

----

@bigcommerce/platform-engineering @bigcommerce/oss-maintainers @bigcommerce/ruby 
