### PR TITLE
Add support for installing Gruf under Ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,12 @@ executors:
       ruby-version:
         type: string
         default: "2.7.1"
+  ruby_3_0:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.0.0"
 
 commands:
   pre-setup:
@@ -195,3 +201,17 @@ workflows:
       - e2e:
           name: "ruby-2_7-e2e"
           e: "ruby_2_7"
+  ruby_3_0:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_0-bundle_audit"
+          e: "ruby_3_0"
+      - rubocop:
+          name: "ruby-3_0-rubocop"
+          e: "ruby_3_0"
+      - rspec-unit:
+          name: "ruby-3_0-rspec"
+          e: "ruby_3_0"
+      - e2e:
+          name: "ruby-3_0-e2e"
+          e: "ruby_3_0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 - Add script/e2e test for full e2e test 
 - Explicitly declare [json gem](https://rubygems.org/gems/json) dependency
 - Update to Rubocop 1.4, add in rubocop-rspec for spec tests
+- Add Ruby 3.0 support
 
 ### 2.8.1
 

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'gruf'
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.4'
+  spec.required_ruby_version = '>= 2.4', '< 3.1'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'bundler-audit', '>= 0.6'


### PR DESCRIPTION
## What? Why?

[gRPC 1.35](https://github.com/grpc/grpc/releases/tag/v1.35.0) and [Protobuf 3.15](https://github.com/protocolbuffers/protobuf/releases/tag/v3.15.0) (and newer versions of both) now support Ruby 3.0.  That means Gruf should now, hopefully, also be usable under Ruby 3.0.

The gemspec currently pins us to `~> 2.4`, which is equivalent to `>= 2.4, < 3.0` -- this PR does the following:

* loosen that requirement to `>= 2.4, < 3.1` to allow installing Gruf under Ruby 3.0
* ~~update the bundler development dependency.  This is maybe unrelated, except that bundler 2.0 was released January 2019-ish and I didn't want to have to install an older version locally to test this change :)~~ this broke CircleCI so I reverted it.

## How was it tested?

* The test suite passes.
* Smoke testing on ruby 3 locally with some simple gRPC services works as expected.

I can't test this change in production quite yet as I still have a few other dependencies that need to be updated for 3.x, so I can't claim that I know it works perfectly just yet.

