### PR TITLE
Allow for float/TimeSpec timeout values on clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 ### Pending release
 
 - Drop support for Ruby 2.4/2.5 to align with Ruby EOL schedule, supporting 2.6+ only
+- Allow for float/TimeSpec timeout values on clients
 
 ### 2.9.0
 

--- a/spec/gruf/client_spec.rb
+++ b/spec/gruf/client_spec.rb
@@ -99,9 +99,34 @@ describe Gruf::Client do
       context 'when the timeout is passed as a string' do
         let(:timeout) { '30' }
 
-        it 'is cast as an int' do
+        it 'is cast as a float' do
           expect(subject).to be_a(described_class)
-          expect(subject.timeout).to eq 30
+          expect(subject.timeout).to eq 30.0
+        end
+      end
+
+      context 'when the timeout is nil' do
+        let(:timeout) { nil }
+
+        it 'is reset as a GRPC::Core::TimeConsts::ZERO' do
+          expect(subject.timeout).to eq ::GRPC::Core::TimeConsts::ZERO
+        end
+      end
+
+      context 'when the timeout is a GRPC::Core::TimeSpec' do
+        let(:timeout) { GRPC::Core::TimeConsts::INFINITE_FUTURE }
+
+        it 'preserves the value' do
+          expect(subject.timeout).to be_a(GRPC::Core::TimeSpec)
+          expect(subject.timeout).to eq timeout
+        end
+      end
+
+      context 'when the timeout is an invalid value that is not castable to a float' do
+        let(:timeout) { Object.new }
+
+        it 'raises an ArgumentError' do
+          expect { subject }.to raise_error(ArgumentError, 'timeout is not a valid value: does not respond to to_f')
         end
       end
     end


### PR DESCRIPTION
## What? Why?

The current gruf implementation always casts `timeout` to an integer when passed. This prevents setting it to a float value, or to a TimeSpec (such as infinite) value, which is supported by gRPC core. This fixes that functionality and allows floats or TimeSpec objects to be passed, while still maintaining the gruf functionality to allow string timeouts to be set (and auto-cast to floats).

## How was it tested?

rspec + manually.

----

@bigcommerce/ruby @bigcommerce/oss-maintainers @alikinir
