### PR TITLE
Add RBS support for Ruby 3+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 *.gem
 /vendor/bundle
 bundler.lock
+/.gem_rbs_collection/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ AllCops:
     - spec/fixtures/**/*
     - spec/pb/**/*
     - spec/demo_server
+    - ./**/*.rbs
 require:
   - rubocop-performance
   - rubocop-rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Add RBS support for Ruby 3.0
+- 
 ### 2.12.0
 
 - Fixed interceptor order to be FIFO as documented, instead of FILO (fixes #139)

--- a/lib/gruf.rbs
+++ b/lib/gruf.rbs
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  VERSION: ::String
+end

--- a/lib/gruf/cli/executor.rb
+++ b/lib/gruf/cli/executor.rb
@@ -25,6 +25,10 @@ module Gruf
     class Executor
       ##
       # @param [Hash|ARGV]
+      # @param [::Gruf::Server|NilClass] server
+      # @param [::Array|NilClass] services
+      # @param [::Gruf::Hooks::Executor|NilClass] hook_executor
+      # @param [::Logger|NilClass] logger
       #
       def initialize(
         args = ARGV,

--- a/lib/gruf/cli/executor.rbs
+++ b/lib/gruf/cli/executor.rbs
@@ -1,0 +1,28 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Cli
+    class Executor
+      def initialize: (?(Hash | ::ARGV) args, ?server: ::Gruf::Server? server, ?services: Array? services, ?hook_executor: ::Gruf::Hooks::Executor? hook_executor, ?logger: ::Logger? logger) -> void
+      def run: () -> void
+
+      private
+
+      def setup!: () -> void
+      def parse_options: () -> ::Slop::Result
+    end
+  end
+end

--- a/lib/gruf/client.rb
+++ b/lib/gruf/client.rb
@@ -154,7 +154,8 @@ module Gruf
     #
     # @param [Symbol] request_method The method name being called on the remote service
     # @param [Hash] params (Optional) A hash of parameters that will populate the request object
-    # @return [Class] The request object that corresponds to the method being called
+    # @return [Object] The request object that corresponds to the method being called
+    # @return [NilClass]
     #
     def request_object(request_method, params = {})
       desc = rpc_desc(request_method)
@@ -165,6 +166,7 @@ module Gruf
     # Properly find the appropriate call signature for the GRPC::GenericService given the request method name
     #
     # @return [Symbol]
+    # @return [NilClass]
     #
     def call_signature(request_method)
       desc = rpc_desc(request_method)
@@ -227,6 +229,8 @@ module Gruf
     # @param [mixed] timeout
     # @return [Float]
     # @return [GRPC::Core::TimeSpec]
+    # @return [Numeric]
+    # @return [Integer]
     #
     def parse_timeout(timeout)
       if timeout.nil?

--- a/lib/gruf/client.rbs
+++ b/lib/gruf/client.rbs
@@ -1,0 +1,38 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  class Client < ::SimpleDelegator
+    attr_reader base_klass: ::Class
+    attr_reader service_klass: ::Class
+    attr_reader opts: ::Hash[::Symbol, ::Object]
+
+    def initialize: (service: ::Module service, ?options: ::Hash[::Symbol, ::Object] options, ?client_options: ::Hash[::Symbol, ::Object] client_options) -> void
+    def call: (::Symbol request_method, ?::Hash[::Symbol, ::Object] params, ?::Hash[::Symbol, ::Object] metadata, ?::Hash[::Symbol, ::Object] opts) { () -> ::Object } -> ::Gruf::Response
+    def timeout: () -> ( Integer | Float | Numeric | ::GRPC::Core::TimeSpec | nil )
+
+    private
+
+    def streaming_request?: (Symbol request_method) -> bool
+    def execute: (::Symbol call_sig, ?Object req, ?Hash[::Symbol, ::Object] metadata, ?::Hash[::Symbol, ::Object] opts) { () -> Object } -> ::Array[::Gruf::Timer::Result, ::GRPC::ActiveCall::Operation]
+    def rpc_desc: (::Symbol request_method) -> ::GRPC::RpcDesc
+    def request_object: (::Symbol request_method, ?::Hash[::Symbol, ::Object] params) -> ( ::Class | nil )
+    def call_signature: (::Symbol request_method) -> ( ::Symbol | nil )
+    def build_metadata: (?::Hash[::Symbol, ::Object] metadata) -> ::Hash[::Symbol, ::Object]
+    def build_ssl_credentials: () -> ( Symbol | GRPC::Core::ChannelCredentials)
+    def error_deserializer_class: () -> ::Class
+    def parse_timeout: (untyped timeout) -> ( ::Float | ::Numeric | ::Integer | ::GRPC::Core::TimeSpec )
+  end
+end

--- a/lib/gruf/client/error.rbs
+++ b/lib/gruf/client/error.rbs
@@ -1,0 +1,82 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  class Client < ::SimpleDelegator
+    class Error < ::StandardError
+      attr_reader error: Object
+      def initialize: (Object error) -> void
+    end
+
+    module Errors
+      class Base < Gruf::Client::Error
+      end
+
+      class Error < Base
+      end
+
+      class Validation < Base
+      end
+
+      class Ok < Base
+      end
+
+      class InvalidArgument < Validation
+      end
+
+      class NotFound < Validation
+      end
+
+      class AlreadyExists < Validation
+      end
+
+      class OutOfRange < Validation
+      end
+
+      class Cancelled < Error
+      end
+
+      class DataLoss < Error
+      end
+
+      class DeadlineExceeded < Error
+      end
+
+      class FailedPrecondition < Error
+      end
+
+      class Internal < Error
+      end
+
+      class PermissionDenied < Error
+      end
+
+      class ResourceExhausted < Error
+      end
+
+      class Unauthenticated < Error
+      end
+
+      class Unavailable < Error
+      end
+
+      class Unimplemented < Error
+      end
+
+      class Unknown < Error
+      end
+    end
+  end
+end

--- a/lib/gruf/client/error_factory.rb
+++ b/lib/gruf/client/error_factory.rb
@@ -43,7 +43,9 @@ module Gruf
       # coalesce them.
       #
       # @param [Exception] exception
-      # @return [Gruf::Client::Errors::Base|SignalException]
+      # @return [Gruf::Client::Errors::Base]
+      # @return [SignalException]
+      # @return [Exception]
       #
       def from_exception(exception)
         # passthrough on Signals, we don't want to mess with these
@@ -78,7 +80,7 @@ module Gruf
 
       ##
       # @param [Exception] exception
-      # @return [Gruf::Client::Errors::Base]
+      # @return [::Class]
       #
       def determine_class(exception)
         error_class = Gruf::Client::Errors.const_get(exception.class.name.demodulize)

--- a/lib/gruf/client/error_factory.rbs
+++ b/lib/gruf/client/error_factory.rbs
@@ -1,0 +1,29 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  class Client < ::SimpleDelegator
+    class ErrorFactory
+      def initialize: (?default_class: ::Class? default_class, ?deserializer_class: ::Class? deserializer_class, ?metadata_key: (Symbol | String)? metadata_key) -> void
+      def from_exception: (::Exception exception) -> ( ::Gruf::Client::Errors::Base | SignalException | Exception )
+
+      private
+
+      def deserialize: (::Gruf::Client::Errors::Base exception) -> String
+      def determine_class: (::Exception exception) -> ::Class
+      def default_serializer: () -> ::Gruf::Serializers::Errors::Base
+    end
+  end
+end

--- a/lib/gruf/configuration.rbs
+++ b/lib/gruf/configuration.rbs
@@ -1,0 +1,32 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Configuration
+    VALID_CONFIG_KEYS: ::Hash[::Symbol, ::Object]
+
+    def self.extended: (::Gruf::Configuration base) -> void
+
+    def configure: () { () -> ::Gruf::Configuration } -> ::Gruf::Configuration
+
+    def options: () -> ::Hash
+
+    def reset: () -> ::Hash
+
+    private
+
+    def environment: () -> ::String
+  end
+end

--- a/lib/gruf/controllers/base.rbs
+++ b/lib/gruf/controllers/base.rbs
@@ -1,0 +1,29 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Controllers
+    class Base
+      attr_reader request: ::Gruf::Controller::Request
+      attr_reader error: ::Gruf::Error
+      attr_reader self.bound_service: ::GRPC::GenericService
+
+      def initialize: (method_key: ::Symbol method_key, service: ::GRPC::GenericService service, rpc_desc: ::GRPC::RpcDesc rpc_desc, active_call: ::GRPC::ActiveCall active_call, message: ::Object message) -> void
+      def self.bind: (::GRPC::GenericService service) -> void
+      def process_action: (::Symbol method_key) { () -> ::Object } -> ::Object
+      def call: (::Symbol method_key) { () -> ::Object } -> ::Object
+    end
+  end
+end

--- a/lib/gruf/controllers/request.rbs
+++ b/lib/gruf/controllers/request.rbs
@@ -1,0 +1,37 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Controllers
+    class Request
+      attr_reader message: ::Object
+      attr_reader active_call: ::GRPC::ActiveCall
+      attr_reader method_key: ::Symbol
+      attr_reader type: ::Gruf::Controllers::Request::Type
+      attr_reader service: ::Class
+
+      class Type
+        def initialize: (::GRPC::RpcDesc rpc_desc) -> void
+      end
+
+      def initialize: (method_key: ::Symbol method_key, service: ::Class service, rpc_desc: ::GRPC::RpcDesc rpc_desc, active_call: ::GRPC::ActiveCall active_call, message: ::Object message) -> void
+      def service_key: () -> ::String
+      def response_class: () -> ::Class
+      def request_class: () -> ::Class
+      def method_name: () -> ::String
+      def messages: () -> (::Enumerable[::Object] | ::Object)
+    end
+  end
+end

--- a/lib/gruf/controllers/service_binder.rbs
+++ b/lib/gruf/controllers/service_binder.rbs
@@ -1,0 +1,31 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Controllers
+    class ServiceBinder
+      class BoundDesc < ::SimpleDelegator
+      end
+
+      def initialize: (::GRPC::GenericService service) -> void
+      def bind!: (::Class controller) -> void
+
+      private
+
+      def bind_method: (::Gruf::Controllers::Base controller, ::Symbol method_name, ::Gruf::Controllers::ServiceBinder::BoundDesc desc) -> untyped
+      def rpc_methods: () -> ::Array[::Gruf::Controllers::ServiceBinder::BoundDesc]
+    end
+  end
+end

--- a/lib/gruf/error.rb
+++ b/lib/gruf/error.rb
@@ -180,7 +180,7 @@ module Gruf
     # gRPC BadStatus code.
     #
     # @param [GRPC::ActiveCall] active_call The marshalled gRPC call
-    # @return [GRPC::BadStatus] The gRPC BadStatus code this error is mapped to
+    # @raise [GRPC::BadStatus] The gRPC BadStatus code this error is mapped to
     #
     def fail!(active_call)
       raise attach_to_call(active_call).grpc_error

--- a/lib/gruf/error.rbs
+++ b/lib/gruf/error.rbs
@@ -1,0 +1,47 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  class Error
+    TYPES: Hash[Symbol, Class]
+    MAX_METADATA_SIZE: ::Integer
+    METADATA_SIZE_EXCEEDED_CODE: ::String
+    METADATA_SIZE_EXCEEDED_MSG: ::String
+
+    attr_accessor code: ::Symbol
+    attr_accessor app_code: ::Symbol
+    attr_accessor message: ::String
+    attr_accessor field_errors: ::Array[::Symbol, ::Gruf::Errors::Field]
+    attr_accessor debug_info: ::Gruf::Errors::DebugInfo
+    attr_writer grpc_error: ::GRPC::BadStatus
+    attr_reader metadata: ::Hash
+
+    def initialize: (?::Hash[::Symbol, ::Object] args) -> void
+    def add_field_error: (::Symbol field_name, ::Symbol error_code, ?::String message) -> void
+    def has_field_errors?: () -> bool
+    def set_debug_info: (::Symbol detail, ?Array[String] stack_trace) -> void
+    def metadata=: (::Hash metadata) -> void
+    def serialize: () -> ::String
+    def attach_to_call: (::GRPC::ActiveCall active_call) -> self
+    def fail!: (::GRPC::ActiveCall active_call) -> void
+    def to_h: () -> { code: ::Symbol, app_code: ::Symbol, message: ::String, field_errors: ::Array[::Symbol, ::Hash], debug_info: ::Hash }
+    def grpc_error: () -> ::GRPC::BadStatus
+
+    private
+
+    def serializer_class: () -> ::Gruf::Serializers::Errors::Base
+    def grpc_class: () -> ::Class
+  end
+end

--- a/lib/gruf/errors/debug_info.rbs
+++ b/lib/gruf/errors/debug_info.rbs
@@ -1,0 +1,26 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Errors
+    class DebugInfo
+      attr_reader detail: String
+      attr_reader stack_trace: Array[String]
+
+      def initialize: (String detail, ?Array[String] stack_trace) -> void
+      def to_h: () -> { detail: String, stack_trace: Array[String] }
+    end
+  end
+end

--- a/lib/gruf/errors/field.rbs
+++ b/lib/gruf/errors/field.rbs
@@ -1,0 +1,27 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Errors
+    class Field
+      attr_reader field_name: ::Symbol
+      attr_reader error_code: ::Symbol
+      attr_reader message: ::String
+
+      def initialize: (::Symbol field_name, ::Symbol error_code, ?::String message) -> void
+      def to_h: () -> { field_name: ::Symbol, error_code: ::Symbol, message: ::String }
+    end
+  end
+end

--- a/lib/gruf/errors/helpers.rbs
+++ b/lib/gruf/errors/helpers.rbs
@@ -1,0 +1,22 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Errors
+    module Helpers
+      def fail!: (::Symbol error_code, ?::Symbol? app_code, ?::String message, ?::Hash[::Symbol, ::Object] metadata) -> void
+    end
+  end
+end

--- a/lib/gruf/hooks/base.rbs
+++ b/lib/gruf/hooks/base.rbs
@@ -1,0 +1,22 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Hooks
+    class Base
+      def initialize: (?options: ::Hash? options) -> void
+    end
+  end
+end

--- a/lib/gruf/hooks/executor.rbs
+++ b/lib/gruf/hooks/executor.rbs
@@ -1,0 +1,23 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Hooks
+    class Executor
+      def initialize: (?hooks: ::Array[::Gruf::Hooks::Base]? hooks) -> void
+      def call: (::Symbol name, ?::Hash[::Symbol, ::Object] arguments) -> void
+    end
+  end
+end

--- a/lib/gruf/hooks/registry.rbs
+++ b/lib/gruf/hooks/registry.rbs
@@ -1,0 +1,37 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Hooks
+    class Registry
+      class HookNotFoundError < StandardError
+      end
+
+      def initialize: () -> void
+      def use: (::Class hook_class, ?::Hash[::Symbol, ::Object] options) -> void
+      def remove: (::Class hook_class) -> void
+      def insert_before: (::Class before_class, ::Class hook_class, ?::Hash[::Symbol, ::Object] options) -> void
+      def insert_after: (::Class after_class, ::Class hook_class, ?::Hash[::Symbol, ::Object] options) -> void
+      def list: () -> ::Array[::Class]
+      def prepare: () -> ::Array[::Gruf::Hooks::Base]
+      def clear: () -> void
+      def count: () -> ::Integer
+
+      private
+
+      def hooks_mutex: () { () -> untyped } -> untyped
+    end
+  end
+end

--- a/lib/gruf/instrumentable_grpc_server.rb
+++ b/lib/gruf/instrumentable_grpc_server.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
 module Gruf
   ##
   # A subclass of GRPC::RpcServer that can be used for enhanced monitoring

--- a/lib/gruf/instrumentable_grpc_server.rbs
+++ b/lib/gruf/instrumentable_grpc_server.rbs
@@ -1,0 +1,26 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  class InstrumentableGrpcServer < ::GRPC::RpcServer
+    def initialize: (?pool_size: Integer pool_size, ?max_waiting_requests: Integer max_waiting_requests, ?poll_period: Integer poll_period, ?pool_keep_alive: Integer pool_keep_alive, ?connect_md_proc: Proc? connect_md_proc, ?server_args: ::Hash[Symbol, Object] server_args, ?interceptors: Array[::Gruf::Interceptors::ServerInterceptor] interceptors, ?event_listener_proc: Proc? event_listener_proc) -> void
+
+    def notify: (Symbol event) -> (nil | untyped)
+
+    def available?: (::Google::Protobuf::Descriptor an_rpc) -> ( bool | nil )
+
+    def implemented?: (::Google::Protobuf::Descriptor an_rpc) -> ( bool | nil )
+  end
+end

--- a/lib/gruf/integrations/rails/railtie.rbs
+++ b/lib/gruf/integrations/rails/railtie.rbs
@@ -1,0 +1,24 @@
+
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Integrations
+    module Rails
+      class Railtie < ::Rails::Railtie
+      end
+    end
+  end
+end

--- a/lib/gruf/interceptors/active_record/connection_reset.rbs
+++ b/lib/gruf/interceptors/active_record/connection_reset.rbs
@@ -1,0 +1,28 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    module ActiveRecord
+      class ConnectionReset < ::Gruf::Interceptors::ServerInterceptor
+        def call: () { () -> ::Object } -> ::Object
+
+        private
+
+        def enabled?: () -> bool
+      end
+    end
+  end
+end

--- a/lib/gruf/interceptors/authentication/basic.rbs
+++ b/lib/gruf/interceptors/authentication/basic.rbs
@@ -1,0 +1,32 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    module Authentication
+      class Basic < Gruf::Interceptors::ServerInterceptor
+        def call: () { () -> ::Object } -> ::Object
+
+        private
+
+        def bypass?: () -> bool
+        def valid?: () -> bool
+        def server_credentials: () -> ::Array[::Hash]
+        def request_credentials: () -> ::String
+        def request_password: () -> ::String
+      end
+    end
+  end
+end

--- a/lib/gruf/interceptors/base.rbs
+++ b/lib/gruf/interceptors/base.rbs
@@ -1,0 +1,26 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    class Base
+      attr_reader request: ::Gruf::Controllers::Request
+      attr_reader error: ::Gruf::Error
+      attr_reader options: ::Hash
+
+      def initialize: (::Gruf::Controllers::Request request, ::Gruf::Error error, ?::Hash[::Symbol, ::Object] options) -> void
+    end
+  end
+end

--- a/lib/gruf/interceptors/client_interceptor.rbs
+++ b/lib/gruf/interceptors/client_interceptor.rbs
@@ -1,0 +1,26 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    class ClientInterceptor < GRPC::ClientInterceptor
+      def call: (request_context: ::Gruf::Outbound::RequestContext request_context) { () -> ::Object } -> ::Object
+      def request_response: (?request: ::Object? request, ?call: ::GRPC::ActiveCall? call, ?method: ::Method? method, ?metadata: ::Hash? metadata) { () -> ::Object } -> ::Object
+      def client_streamer: (?requests: ::Enumerable? requests, ?call: ::GRPC::ActiveCall? call, ?method: ::Method? method, ?metadata: ::Hash? metadata) { () -> ::Object } -> ::Object
+      def server_streamer: (?request: ::Object? request, ?call: ::GRPC::ActiveCall? call, ?method: ::Method? method, ?metadata: ::Hash? metadata) { () -> ::Object } -> ::Object
+      def bidi_streamer: (?requests: ::Enumerable? requests, ?call: ::GRPC::ActiveCall? call, ?method: ::Method? method, ?metadata: ::Hash? metadata) { () -> ::Object } -> ::Object
+    end
+  end
+end

--- a/lib/gruf/interceptors/context.rbs
+++ b/lib/gruf/interceptors/context.rbs
@@ -1,0 +1,23 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    class Context
+      def initialize: (?Array[Gruf::Interceptors::ServerInterceptor]? interceptors) -> void
+      def intercept!: () { () -> ::Object } -> ::Object
+    end
+  end
+end

--- a/lib/gruf/interceptors/instrumentation/output_metadata_timer.rbs
+++ b/lib/gruf/interceptors/instrumentation/output_metadata_timer.rbs
@@ -1,0 +1,29 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    module Instrumentation
+      class OutputMetadataTimer < ::Gruf::Interceptors::ServerInterceptor
+        def call: () { () -> ::Object } -> (nil | ::Object)
+
+        private
+
+        def metadata_key: () -> ::Symbol
+        def output_metadata: () -> ::Hash
+      end
+    end
+  end
+end

--- a/lib/gruf/interceptors/instrumentation/request_logging/formatters/base.rbs
+++ b/lib/gruf/interceptors/instrumentation/request_logging/formatters/base.rbs
@@ -1,0 +1,28 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    module Instrumentation
+      module RequestLogging
+        module Formatters
+          class Base
+            def format: (::Hash _payload, request: ::Gruf::Controllers::Request request, result: ::Gruf::Interceptors::Timer::Result result) -> ::String
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gruf/interceptors/instrumentation/request_logging/formatters/logstash.rbs
+++ b/lib/gruf/interceptors/instrumentation/request_logging/formatters/logstash.rbs
@@ -1,0 +1,28 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    module Instrumentation
+      module RequestLogging
+        module Formatters
+          class Logstash < Base
+            def format: (::Hash payload, request: ::Gruf::Controllers::Request request, result: ::Gruf::Interceptors::Timer::Result result) -> ::String
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gruf/interceptors/instrumentation/request_logging/formatters/plain.rbs
+++ b/lib/gruf/interceptors/instrumentation/request_logging/formatters/plain.rbs
@@ -1,0 +1,28 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    module Instrumentation
+      module RequestLogging
+        module Formatters
+          class Plain < Base
+            def format: (::Hash payload, request: ::Gruf::Controllers::Request request, result: ::Gruf::Interceptors::Timer::Result result) -> ::String
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
@@ -59,7 +59,7 @@ module Gruf
           ###
           # Log the request, sending it to the appropriate formatter
           #
-          # @return [String]
+          # @return [::Object]
           #
           def call(&block)
             return yield if options.fetch(:ignore_methods, [])&.include?(request.method_name)
@@ -132,7 +132,7 @@ module Gruf
           #
           # @param [Object] response The response object
           # @param [Boolean] successful If the response was successful
-          # @return [Boolean] The proper status code
+          # @return [Integer] The proper status code
           #
           def status(response, successful)
             successful ? GRPC::Core::StatusCodes::OK : response.code

--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rbs
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rbs
@@ -1,0 +1,41 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    module Instrumentation
+      module RequestLogging
+        class InvalidFormatterError < StandardError
+        end
+
+        class Interceptor < ::Gruf::Interceptors::ServerInterceptor
+          LOG_LEVEL_MAP: ::Hash[::String, ::Symbol]
+
+          def call: () { () -> ::Object } -> ::Object
+
+          private
+
+          def logger: () -> ::Logger
+          def message: (::Gruf::Controllers::Request request, ::Gruf::Interceptors::Timer::Result result) -> ::String
+          def status: (::Object response, bool successful) -> Integer
+          def formatter: () -> ::Gruf::Instrumentation::RequestLogging::Formatters::Base
+          def sanitize: (?::Hash[::Symbol, ::Object] params) -> ::Hash
+          def redact!: (?::Array[::Symbol] parts, ?::Integer idx, ?::Hash[::Symbol, ::Object] params, ?::String redacted_string) -> void
+          def hash_deep_redact!: (::Hash hash, ::String redacted_string) -> void
+        end
+      end
+    end
+  end
+end

--- a/lib/gruf/interceptors/instrumentation/statsd.rb
+++ b/lib/gruf/interceptors/instrumentation/statsd.rb
@@ -70,6 +70,7 @@ module Gruf
 
         ##
         # @return [::Statsd] Return the given StatsD client
+        # @return [NilClass]
         #
         def client
           @client ||= options.fetch(:client, nil)

--- a/lib/gruf/interceptors/instrumentation/statsd.rbs
+++ b/lib/gruf/interceptors/instrumentation/statsd.rbs
@@ -1,0 +1,31 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    module Instrumentation
+      class Statsd < Gruf::Interceptors::ServerInterceptor
+        def call: () { () -> ::Object } -> ::Object
+
+        private
+
+        def postfix: (bool successful) -> ::String
+        def route_key: () -> ::String
+        def key_prefix: () -> ::String
+        def client: () -> (::StatsD | nil)
+      end
+    end
+  end
+end

--- a/lib/gruf/interceptors/registry.rbs
+++ b/lib/gruf/interceptors/registry.rbs
@@ -1,0 +1,37 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    class Registry
+      class InterceptorNotFoundError < StandardError
+      end
+
+      def initialize: () -> void
+      def use: (::Class interceptor_class, ?::Hash[::Symbol, ::Object] options) -> void
+      def remove: (::Class interceptor_class) -> void
+      def insert_before: (::Class before_class, ::Class interceptor_class, ?::Hash[::Symbol, ::Object] options) -> void
+      def insert_after: (::Class after_class, ::Class interceptor_class, ?::Hash[::Symbol, ::Object] options) -> void
+      def list: () -> ::Array[::Class]
+      def prepare: (::Class request, ::Class error) -> ::Array[::Gruf::Interceptors::Base]
+      def clear: () -> void
+      def count: () -> ::Integer
+
+      private
+
+      def interceptors_mutex: () { () -> ::Object } -> ::Object
+    end
+  end
+end

--- a/lib/gruf/interceptors/server_interceptor.rbs
+++ b/lib/gruf/interceptors/server_interceptor.rbs
@@ -1,0 +1,22 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    class ServerInterceptor < Base
+      def call: () -> void
+    end
+  end
+end

--- a/lib/gruf/interceptors/timer.rb
+++ b/lib/gruf/interceptors/timer.rb
@@ -24,9 +24,6 @@ module Gruf
       ##
       # Represents a timed result for an interceptor
       #
-      # @property [Object] message The protobuf message
-      # @property [Float] elapsed The elapsed time of the request
-      #
       class Result
         # @!attribute [r] message
         #   @return [Object] The returned protobuf message

--- a/lib/gruf/interceptors/timer.rbs
+++ b/lib/gruf/interceptors/timer.rbs
@@ -1,0 +1,32 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Interceptors
+    class Timer
+      class Result
+        attr_reader message: ::Object
+        attr_reader elapsed: ::Float
+
+        def initialize: (::Object message, ::Float elapsed, bool successful) -> void
+        def successful?: () -> bool
+        def message_class_name: () -> ::String
+        def elapsed_rounded: (?precision: ::Integer precision) -> (::Float | ::Integer)
+      end
+
+      def self.time: () { () -> ::Object } -> ::Gruf::Interceptors::Timer::Result
+    end
+  end
+end

--- a/lib/gruf/loggable.rbs
+++ b/lib/gruf/loggable.rbs
@@ -1,0 +1,20 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Loggable
+    def logger: () -> ::Logger
+  end
+end

--- a/lib/gruf/logging.rbs
+++ b/lib/gruf/logging.rbs
@@ -1,0 +1,28 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Logger
+    def logger: () -> ::Logger
+  end
+
+  module GrpcLogger
+    def logger: () -> ::Logger
+  end
+end
+
+module GRPC
+  extend Gruf::GrpcLogger
+end

--- a/lib/gruf/outbound/request_context.rbs
+++ b/lib/gruf/outbound/request_context.rbs
@@ -1,0 +1,30 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Outbound
+    class RequestContext
+      attr_reader type: ::Symbol
+      attr_reader requests: ::Enumerable
+      attr_reader call: ::GRPC::ActiveCall
+      attr_reader method: ::Method
+      attr_reader metadata: ::Hash
+
+      def initialize: (type: ::Symbol `type`, requests: ::Enumerable requests, call: ::GRPC::ActiveCall call, method: ::Method method, metadata: ::Hash metadata) -> void
+      def method_name: () -> ::String
+      def route_key: () -> ::String
+    end
+  end
+end

--- a/lib/gruf/response.rbs
+++ b/lib/gruf/response.rbs
@@ -1,0 +1,31 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  class Response
+    attr_reader operation: ::GRPC::ActiveCall::Operation
+    attr_reader metadata: ::Hash
+    attr_reader trailing_metadata: ::Hash
+    attr_reader deadline: ::Time
+    attr_reader cancelled: bool
+    attr_reader execution_time: ::Float
+
+    def initialize: (operation: ::GRPC::ActiveCall::Operation operation, message: ::Object message, ?execution_time: ::Float? execution_time) -> void
+
+    def message: () -> ::Object
+
+    def internal_execution_time: () -> ::Float
+  end
+end

--- a/lib/gruf/serializers/errors/base.rbs
+++ b/lib/gruf/serializers/errors/base.rbs
@@ -1,0 +1,28 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Serializers
+    module Errors
+      class Base
+        attr_reader error: (::Gruf::Error | String)
+
+        def initialize: ((::Gruf::Error | String) err) -> void
+        def serialize: () -> ::String
+        def deserialize: () -> (::Object | ::Hash)
+      end
+    end
+  end
+end

--- a/lib/gruf/serializers/errors/json.rbs
+++ b/lib/gruf/serializers/errors/json.rbs
@@ -1,0 +1,25 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  module Serializers
+    module Errors
+      class Json < Base
+        def serialize: () -> ::String
+        def deserialize: () -> ::Hash
+      end
+    end
+  end
+end

--- a/lib/gruf/server.rb
+++ b/lib/gruf/server.rb
@@ -248,7 +248,7 @@ module Gruf
     # @param [String]
     #
     def controllers_path
-      options.fetch(:controllers_path, Gruf.controllers_path)
+      options.fetch(:controllers_path, Gruf.controllers_path).to_s
     end
 
     ##

--- a/lib/gruf/server.rbs
+++ b/lib/gruf/server.rbs
@@ -1,0 +1,44 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  class Server
+    class ServerAlreadyStartedError < StandardError
+    end
+
+    attr_reader port: ::Integer
+    attr_reader options: ::Hash[::Symbol, ::Object]
+
+    def initialize: (?::Hash[::Symbol, ::Object] opts) -> void
+    def server: () -> ::GRPC::RpcServer
+    def start!: () -> void
+    def add_service: (Class klass) -> void
+    def add_interceptor: (::Class klass, ?::Hash[::Symbol, ::Object] opts) -> void
+    def insert_interceptor_before: (::Class before_class, ::Class interceptor_class, ?::Hash[::Symbol, ::Object] opts) -> void
+    def insert_interceptor_after: (::Class after_class, ::Class interceptor_class, ?::Hash[::Symbol, ::Object] opts) -> void
+    def list_interceptors: () -> ::Array[::Class]
+    def remove_interceptor: (::Class klass) -> void
+    def clear_interceptors: () -> void
+
+    private
+
+    def setup: () -> void
+    def setup_signal_handlers: () -> void
+    def load_controllers: () -> void
+    def controllers_path: () -> ::String
+    def ssl_credentials: () -> (:this_port_is_insecure | ::GRPC::Core::ServerCredentials)
+    def update_proc_title: (::Symbol state) -> void
+  end
+end

--- a/lib/gruf/synchronized_client.rbs
+++ b/lib/gruf/synchronized_client.rbs
@@ -1,0 +1,23 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  class SynchronizedClient < ::Gruf::Client
+    attr_reader unsynchronized_methods: Array[::Symbol]
+
+    def initialize: (service: ::Class service, ?options: ::Hash[Symbol, Object] options, ?client_options: ::Hash[Symbol, Object] client_options) -> void
+    def call: (Symbol request_method, ?::Hash[Symbol, Object] params, ?::Hash[Symbol, Object] metadata, ?::Hash[Symbol, Object] opts) { () -> untyped } -> ::Gruf::Response
+  end
+end

--- a/lib/gruf/timer.rb
+++ b/lib/gruf/timer.rb
@@ -29,15 +29,12 @@ module Gruf
     #   result.time # => 1.10123
     #   result.result # => 'my_thing_is_done'
     #
-    # @property [Object] result The result of the block that was called
-    # @property [Float] time The time, in ms, of the block execution
-    #
     class Result
       # @!attribute [r] result
-      #   @return [mixed]
+      #   @return [Object] The result of the block that was called
       attr_reader :result
       # @!attribute [r] time
-      #   @return [Float]
+      #   @return [Float] The time, in ms, of the block execution
       attr_reader :time
 
       ##

--- a/lib/gruf/timer.rbs
+++ b/lib/gruf/timer.rbs
@@ -1,0 +1,29 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  class Timer
+    class Result
+      attr_reader result: ::Object
+      attr_reader time: ::Float
+
+      def initialize: (::Object result, ::Float time) -> void
+
+      def success?: () -> bool
+    end
+
+    def self.time: () { () -> Object } -> ::Gruf::Timer::Result
+  end
+end

--- a/lib/gruf/version.rbs
+++ b/lib/gruf/version.rbs
@@ -1,0 +1,18 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Gruf
+  VERSION: ::String
+end

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,0 +1,72 @@
+---
+sources:
+- name: ruby/gem_rbs_collection
+  remote: https://github.com/ruby/gem_rbs_collection.git
+  revision: main
+  repo_dir: gems
+path: ".gem_rbs_collection"
+gems:
+- name: activesupport
+  version: '6.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: e67a6cc67c144e13e3d7a3e2e299f81f0a4e1778
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: ast
+  version: '2.4'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: e67a6cc67c144e13e3d7a3e2e299f81f0a4e1778
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: json
+  version: '0'
+  source:
+    type: stdlib
+- name: parallel
+  version: '1.20'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: e67a6cc67c144e13e3d7a3e2e299f81f0a4e1778
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: rainbow
+  version: '3.0'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: e67a6cc67c144e13e3d7a3e2e299f81f0a4e1778
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
+- name: monitor
+  version: '0'
+  source:
+    type: stdlib
+- name: date
+  version: '0'
+  source:
+    type: stdlib
+- name: singleton
+  version: '0'
+  source:
+    type: stdlib
+- name: logger
+  version: '0'
+  source:
+    type: stdlib
+- name: mutex_m
+  version: '0'
+  source:
+    type: stdlib
+- name: time
+  version: '0'
+  source:
+    type: stdlib
+- name: pathname
+  version: '0'
+  source:
+    type: stdlib

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -1,0 +1,15 @@
+# Download sources
+sources:
+  - name: ruby/gem_rbs_collection
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    revision: main
+    repo_dir: gems
+
+# A directory to install the downloaded RBSs
+path: .gem_rbs_collection
+
+gems:
+  # Skip loading rbs gem's RBS.
+  # It's unnecessary if you don't use rbs as a library.
+  - name: rbs
+    ignore: true


### PR DESCRIPTION
## What? Why?

Adds .rbs files for type checking support for Ruby 3+.

Note we're not implementing Steep or other static checkers yet as libraries Gruf depends on are not yet fully RBS-supported.

## How was it tested?

rspec, rubocop, and through an IDE (such as RubyMine) that has native RBS support.

----

@bigcommerce/ruby 
