### PR TITLE
Fix gRPC Ruby library link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/bigcommerce/gruf/tree/main.svg?style=svg)](https://circleci.com/gh/bigcommerce/gruf/tree/main) [![Gem Version](https://badge.fury.io/rb/gruf.svg)](https://badge.fury.io/rb/gruf) [![Documentation](https://inch-ci.org/github/bigcommerce/gruf.svg?branch=main)](https://inch-ci.org/github/bigcommerce/gruf?branch=main)
 
-gruf is a Ruby framework that wraps the [gRPC Ruby library](https://github.com/grpc/grpc/tree/main/src/ruby) to
+gruf is a Ruby framework that wraps the [gRPC Ruby library](https://github.com/grpc/grpc/tree/master/src/ruby) to
 provide a more streamlined integration into Ruby and Ruby on Rails applications.
 
 It provides an abstracted server and client for gRPC services, along with other tools to help get gRPC services in Ruby


### PR DESCRIPTION
I applaud the move from `master` to `main` for branch naming, but the
Ruby gRPC library still uses `master`. This commit fixes that broken
link.

## What? Why?

This fixes the broken link in the README. The link to the Ruby gRPC library broke with [this commit](https://github.com/bigcommerce/gruf/commit/a9a38179f61ed53f1e92846b9138f59155554780#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5) since they still call their main branch `master`. That meant getting a github 404.

## How was it tested?

I clicked the link and got the library instead of the 404.
