### PR TITLE
Relax required ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,12 @@ executors:
       ruby-version:
         type: string
         default: "3.0"
+  ruby_3_1:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.1"
 
 commands:
   pre-setup:
@@ -185,3 +191,17 @@ workflows:
       - e2e:
           name: "ruby-3_0-e2e"
           e: "ruby_3_0"
+  ruby_3_1:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_1-bundle_audit"
+          e: "ruby_3_1"
+      - rubocop:
+          name: "ruby-3_1-rubocop"
+          e: "ruby_3_1"
+      - rspec-unit:
+          name: "ruby-3_1-rspec"
+          e: "ruby_3_1"
+      - e2e:
+          name: "ruby-3_1-e2e"
+          e: "ruby_3_1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Relax ruby version requirements to >= 2.6
+
 ### 2.11.0
 
-- Restrict grpc gem to <= 1.41.0 due to regressions in grpc 1.42.x 
+- Restrict grpc gem to <= 1.41.0 due to regressions in grpc 1.42.x
 - Fallback to stdout logger at INFO if no logger is setup
 - Better handling of namespace collisions with Rails
 - Add `GRPC_SERVER_HOST` and `GRPC_SERVER_PORT` for ENV configuration of the server host+port
@@ -44,7 +46,7 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### 2.8.0
 
-- Pass the controller request object into the request logging formatters [#92]  
+- Pass the controller request object into the request logging formatters [#92]
 
 ### 2.7.1
 
@@ -57,12 +59,12 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 ### 2.6.1
 
 - Add frozen_string_literal: true to files, update rubocop to 0.68
-  
+
 ### 2.6.0
 
 - Drop Ruby 2.2 support
-- Abstract gruf controller's send to make it usable in filters 
-- Adjusts configuration reset into a Railtie for Rails systems to ensure proper OOE 
+- Abstract gruf controller's send to make it usable in filters
+- Adjusts configuration reset into a Railtie for Rails systems to ensure proper OOE
 - Bump rubocop to 0.64, address violations, update activesupport/concurrent-ruby dependencies to have a min version
 
 ### 2.5.2

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'gruf'
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.6', '< 3.1'
+  spec.required_ruby_version = '>= 2.6'
 
   spec.metadata['rubygems_mfa_required'] = 'true'
 


### PR DESCRIPTION
## What? Why?

Ruby 3.1 was released.
I used no max version, the same way Rails does (amongst others).

## How was it tested?

Ran rspec with ruby 3.1

