### PR TITLE
Fix issue with race condition in server starts where servers may fail to bind connections and never reach serving state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+### 2.13.1
+
+- Fix issue with race condition in server starts where servers may fail to bind connections and never reach  
+  serving state (fixes #147)
+ 
 ### 2.13.0
 
 - Remove server mutex handling in deference to core grpc signal handling

--- a/lib/gruf/server.rb
+++ b/lib/gruf/server.rb
@@ -90,7 +90,6 @@ module Gruf
         logger.info { "Starting gruf server at #{@hostname}..." }
         server.run_till_terminated_or_interrupted(KILL_SIGNALS)
       end
-      server.wait_till_running
       @started = true
       update_proc_title(:serving)
       server_thread.join

--- a/spec/gruf/client_spec.rb
+++ b/spec/gruf/client_spec.rb
@@ -145,7 +145,10 @@ describe Gruf::Client do
       let(:method_name) { :GetThing }
 
       it 'calls the appropriate method with the right signature' do
-        expect(client).to receive(:get_thing).with(req, return_op: true, metadata: metadata).and_return(op)
+        expect(client).to receive(:get_thing).with(
+          an_instance_of(::Rpc::GetThingRequest),
+          { return_op: true, metadata: metadata }
+        ).and_return(op)
         expect(subject).to be_truthy
       end
 
@@ -155,7 +158,10 @@ describe Gruf::Client do
 
         it 'passes the deadline into the call' do
           expect(client).to receive(:get_thing)
-            .with(req, return_op: true, metadata: metadata, deadline: deadline).and_return(op)
+            .with(
+              an_instance_of(::Rpc::GetThingRequest),
+              { return_op: true, metadata: metadata, deadline: deadline }
+            ).and_return(op)
           expect(subject).to be_truthy
         end
       end


### PR DESCRIPTION
## What? Why?

Fixes issues introduced in ef139b7567f0387cf784ddc7e11f81d62eaea41f, fixes #147.

There seems to be a race condition when starting a `GRPC::RpcServer` in a thread, and attempting to use `server.wait_till_running` in the parent thread - `wait_till_running` never proceeds, even after the server is started. Us calling `server_thread.join` _after_ the `wait_till_running` call compounds this (likely the issue that the Thread never finishes executing and binding the connections before we proceed to a serving state).

This means that 2.13.0 is, in certain cases, starting servers that fail to establish serving connections properly.

This PR removes the wait_till_running call, and just joins on the Thread, allowing gRPC to handle the signals internally. While this means we will be updating the process title to `serving` potentially nanoseconds _prior_ to it actually being running, that seems like a minuscule, acceptable cost given that gRPC does not accept a post-execution block to its run method.

## How was it tested?

`script/e2e`, rspec functional tests, as well as manual testing through `spec/demo_server` and running RPC calls against it.