### PR TITLE
Set default client host to 0.0.0.0:9001 (same as default server host)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Set default client host to 0.0.0.0:9001 (same as default server host)
 - Add support for Ruby 3.1
 
 ### 2.13.1

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -84,7 +84,7 @@ module Gruf
       interceptors: nil,
       hooks: nil,
       default_channel_credentials: nil,
-      default_client_host: '',
+      default_client_host: '0.0.0.0:9001',
       use_ssl: false,
       ssl_crt_file: '',
       ssl_key_file: '',


### PR DESCRIPTION
## What? Why?

Sets the default client host to 0.0.0.0:9001, which is the same as the default server host (the match is useful for local testing).

This fixes #149, in where core grpc gem changes now break if the channel host is not explicitly specified.

## How was it tested?

rspec, manual