### PR TITLE
Fix issue where the server object hits thread contention in certain race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Fix issue where the server object hits thread contention in certain race conditions
+
 ### 2.14.0
 
 - Set default client host to 0.0.0.0:9001 (same as default server host)

--- a/lib/gruf/server.rb
+++ b/lib/gruf/server.rb
@@ -54,28 +54,30 @@ module Gruf
     # @return [GRPC::RpcServer] The GRPC server running
     #
     def server
-      @server ||= begin
-        # For backward compatibility, we allow these options to be passed directly
-        # in the Gruf::Server options, or via Gruf.rpc_server_options.
-        server_options = {
-          pool_size: options.fetch(:pool_size, Gruf.rpc_server_options[:pool_size]),
-          max_waiting_requests: options.fetch(:max_waiting_requests, Gruf.rpc_server_options[:max_waiting_requests]),
-          poll_period: options.fetch(:poll_period, Gruf.rpc_server_options[:poll_period]),
-          pool_keep_alive: options.fetch(:pool_keep_alive, Gruf.rpc_server_options[:pool_keep_alive]),
-          connect_md_proc: options.fetch(:connect_md_proc, Gruf.rpc_server_options[:connect_md_proc]),
-          server_args: options.fetch(:server_args, Gruf.rpc_server_options[:server_args])
-        }
+      server_mutex do
+        @server ||= begin
+          # For backward compatibility, we allow these options to be passed directly
+          # in the Gruf::Server options, or via Gruf.rpc_server_options.
+          server_options = {
+            pool_size: options.fetch(:pool_size, Gruf.rpc_server_options[:pool_size]),
+            max_waiting_requests: options.fetch(:max_waiting_requests, Gruf.rpc_server_options[:max_waiting_requests]),
+            poll_period: options.fetch(:poll_period, Gruf.rpc_server_options[:poll_period]),
+            pool_keep_alive: options.fetch(:pool_keep_alive, Gruf.rpc_server_options[:pool_keep_alive]),
+            connect_md_proc: options.fetch(:connect_md_proc, Gruf.rpc_server_options[:connect_md_proc]),
+            server_args: options.fetch(:server_args, Gruf.rpc_server_options[:server_args])
+          }
 
-        server = if @event_listener_proc
-                   server_options[:event_listener_proc] = @event_listener_proc
-                   Gruf::InstrumentableGrpcServer.new(**server_options)
-                 else
-                   GRPC::RpcServer.new(**server_options)
-                 end
+          server = if @event_listener_proc
+                     server_options[:event_listener_proc] = @event_listener_proc
+                     Gruf::InstrumentableGrpcServer.new(**server_options)
+                   else
+                     GRPC::RpcServer.new(**server_options)
+                   end
 
-        @port = server.add_http2_port(@hostname, ssl_credentials)
-        @services.each { |s| server.handle(s) }
-        server
+          @port = server.add_http2_port(@hostname, ssl_credentials)
+          @services.each { |s| server.handle(s) }
+          server
+        end
       end
     end
 
@@ -242,5 +244,17 @@ module Gruf
       Process.setproctitle("gruf #{Gruf::VERSION} -- #{state}")
     end
     # :nocov:
+    #
+
+    ##
+    # Handle thread-safe access to the server
+    #
+    def server_mutex(&block)
+      @server_mutex ||= begin
+        require 'monitor'
+        Monitor.new
+      end
+      @server_mutex.synchronize(&block)
+    end
   end
 end

--- a/spec/gruf/server_spec.rb
+++ b/spec/gruf/server_spec.rb
@@ -89,6 +89,17 @@ describe Gruf::Server do
     end
   end
 
+  describe '#server' do
+    it 'accesses the server in a thread-safe manner' do
+      gruf_server.send(:server_mutex) { true }
+      expect(gruf_server.instance_variable_get(:@server_mutex)).to receive(:synchronize).and_yield.twice
+      threads = []
+      threads << Thread.new { gruf_server.server }
+      threads << Thread.new { gruf_server.server }
+      threads.each(&:join)
+    end
+  end
+
   describe '#add_service' do
     subject { gruf_server.add_service(service) }
 


### PR DESCRIPTION
## What? Why?

In `Gruf::Server`, we thread out the starting of the server to allow for updating the process title and storing run state. `server`, which is the `GRPC::RpcServer`, is memoized on the `Gruf::Server` instance. However, in the current implementation, we were not protecting that memoization with a mutex to ensure thread-safety. This is especially problematic as the first time that the `server` method is called is inside the server starting thread (not the parent).

This PR adds such a mutex and ensures that the server variable is synchronized during access, so as to safely allow access to it and prevent the race condition where the server is unable to serve certain requests (like health checks).

## How was it tested?

rspec, manually:

```
18:34:26 grpc.1      | [DEBUG] {"message":"[GRPC::Ok] (health.health.check)","status":0,"service":"health.health","method":"check","action":"check","grpc_status":"GRPC::Ok","duration":2.42,"thread_id":658020,"time":"2022-04-13 18:34:26 -0500","host":"V4042M6DQ1","format":"json"}
```

Confirmed this fixes the issue on all versions of grpc 1.40-1.45.