### PR TITLE
Fix rubocop configuration and failing cop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       - pre-setup
       - bundle-install:
           <<: *gem_cache_key
-      - bundle-audit
+      - rubocop
   rspec-unit:
     executor: <<parameters.e>>
     parameters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Update `Gruf:Configuration#environment` to use `ENV.fetch`
+
 ### 2.14.1
 
 - Fix issue where the server object hits thread contention in certain race conditions

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -194,7 +194,7 @@ module Gruf
       if defined?(::Rails)
         ::Rails.env.to_s
       else
-        (ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'development').to_s
+        ENV.fetch('RACK_ENV') { ENV.fetch('RAILS_ENV', 'development') }.to_s
       end
     end
 

--- a/spec/gruf/configuration_spec.rb
+++ b/spec/gruf/configuration_spec.rb
@@ -39,10 +39,18 @@ describe Gruf::Configuration do
   describe '.environment' do
     subject { obj.send(:environment) }
 
+    let!(:previous_rack_env) { ENV.fetch('RACK_ENV', nil) }
+    let!(:previous_rails_env) { ENV.fetch('RAILS_ENV', nil) }
+
+    after do
+      ENV['RACK_ENV'] = previous_rack_env
+      ENV['RAILS_ENV'] = previous_rails_env
+    end
+
     context 'with ENV RAILS_ENV' do
       before do
-        allow(ENV).to receive(:[]).with('RACK_ENV').and_return nil
-        allow(ENV).to receive(:[]).with('RAILS_ENV').and_return 'production'
+        ENV['RACK_ENV'] = nil
+        ENV['RAILS_ENV'] = 'production'
       end
 
       it 'returns the proper environment' do
@@ -52,8 +60,8 @@ describe Gruf::Configuration do
 
     context 'with ENV RACK_ENV' do
       before do
-        allow(ENV).to receive(:[]).with('RACK_ENV').and_return 'production'
-        allow(ENV).to receive(:[]).with('RAILS_ENV').and_return nil
+        ENV['RACK_ENV'] = 'production'
+        ENV['RAILS_ENV'] = nil
       end
 
       it 'returns the proper environment' do

--- a/spec/gruf/configuration_spec.rb
+++ b/spec/gruf/configuration_spec.rb
@@ -39,19 +39,14 @@ describe Gruf::Configuration do
   describe '.environment' do
     subject { obj.send(:environment) }
 
-    let!(:previous_rack_env) { ENV.fetch('RACK_ENV', nil) }
-    let!(:previous_rails_env) { ENV.fetch('RAILS_ENV', nil) }
+    let(:env_vars) { {} }
 
-    after do
-      ENV['RACK_ENV'] = previous_rack_env
-      ENV['RAILS_ENV'] = previous_rails_env
+    before do
+      stub_const('ENV', env_vars)
     end
 
     context 'with ENV RAILS_ENV' do
-      before do
-        ENV['RACK_ENV'] = nil
-        ENV['RAILS_ENV'] = 'production'
-      end
+      let(:env_vars) { { 'RAILS_ENV' => 'production' } }
 
       it 'returns the proper environment' do
         expect(subject).to eq 'production'
@@ -59,10 +54,7 @@ describe Gruf::Configuration do
     end
 
     context 'with ENV RACK_ENV' do
-      before do
-        ENV['RACK_ENV'] = 'production'
-        ENV['RAILS_ENV'] = nil
-      end
+      let(:env_vars) { { 'RACK_ENV' => 'production' } }
 
       it 'returns the proper environment' do
         expect(subject).to eq 'production'


### PR DESCRIPTION
## What? Why?

The `rubocop` job in CircleCI was not running, and instead was calling `bundle-audit`  a second time. This PR corrects that and fixes a found `rubocop` error with `Style/FetchEnvVar` in `Gruf::Configuration`.

## How was it tested?

Run `rubocop` and `rspec` locally.
