### PR TITLE
Add Rails Integration

### DIFF
--- a/bin/gruf
+++ b/bin/gruf
@@ -25,5 +25,12 @@ end
 load 'config/environment.rb' if defined?(Rails)
 require 'gruf'
 
-cli = Gruf::Cli::Executor.new
-cli.run
+begin
+  cli = Gruf::Cli::Executor.new
+  cli.run(ARGV)
+rescue => e
+  raise e if $DEBUG
+  STDERR.puts e.message
+  STDERR.puts e.backtrace.join("\n")
+  exit 1
+end

--- a/lib/gruf/cli/executor.rb
+++ b/lib/gruf/cli/executor.rb
@@ -23,67 +23,94 @@ module Gruf
     # Handles execution of the gruf binstub, along with command-line arguments
     #
     class Executor
+      include Gruf::Loggable
+
       class NoServicesBoundError < StandardError; end
 
+      KILL_SIGNALS = %w[INT TERM QUIT].freeze
+
+      # Run CLI inside the current process and shutdown at exit
+      def self.embed!(args = [])
+        new(embedded: true).tap do |cli|
+          cli.run(args)
+          at_exit { cli.shutdown }
+        end
+      end
+
+      attr_reader :server, :embedded
+      alias embedded? embedded
+
       ##
-      # @param [Hash|ARGV]
+      # @param [Boolean] embedded
       # @param [::Gruf::Server|NilClass] server
       # @param [Array<Class>|NilClass] services
       # @param [Gruf::Hooks::Executor|NilClass] hook_executor
-      # @param [Logger|NilClass] logger
       #
       def initialize(
-        args = ARGV,
+        embedded: false,
         server: nil,
         services: nil,
-        hook_executor: nil,
-        logger: nil
+        hook_executor: nil
       )
-        @args = args
-        setup! # ensure we set some defaults from CLI here so we can allow configuration
+        @embedded = embedded
         @services = services.is_a?(Array) ? services : []
-        @hook_executor = hook_executor || Gruf::Hooks::Executor.new(hooks: Gruf.hooks&.prepare)
-        @server = server || Gruf::Server.new(Gruf.server_options)
-        @logger = logger || Gruf.logger || ::Logger.new($stderr)
+        @hook_executor = hook_executor
+        @server = server
       end
 
       ##
       # Run the server
+      # @param [Hash|ARGV] args
       #
-      def run
+      def run(args = [])
+        @args = args
+        setup_options! # ensure we set some defaults from CLI here so we can allow configuration
+        setup!
+
         exception = nil
-        # wait to load controllers until last possible second to allow late configuration
-        ::Gruf.autoloaders.load!(controllers_path: Gruf.controllers_path)
-        # allow lazy registering globally as late as possible, this allows more flexible binstub injections
-        @services = ::Gruf.services unless @services&.any?
 
-        unless @services.any?
-          raise NoServicesBoundError,
-                'No services bound to this gruf process; please bind a service to a Gruf controller ' \
-                'to start the server successfully'
-        end
-
+        update_proc_title(:starting)
         begin
           @services.each { |s| @server.add_service(s) }
           @hook_executor.call(:before_server_start, server: @server)
-          @server.start!
+          @server.start
         rescue StandardError => e
           exception = e
           # Catch the exception here so that we always ensure the post hook runs
           # This allows systems wanting to provide external server instrumentation
           # the ability to properly handle server failures
-          @logger.fatal("FATAL ERROR: #{e.message} #{e.backtrace.join("\n")}")
+          logger.fatal "FATAL ERROR: #{e.message} #{e.backtrace.join("\n")}"
         end
+        update_proc_title(:serving)
+
+        if exception
+          shutdown
+          raise exception
+        end
+
+        shutdown_when_terminated unless embedded?
+      end
+
+      def shutdown
+        server&.stop
         @hook_executor.call(:after_server_stop, server: @server)
-        raise exception if exception
+        update_proc_title(:stopped)
       end
 
       private
 
+      def shutdown_when_terminated
+        wait_till_terminated
+      rescue Interrupt => e
+        logger.info "[gruf] Stopping... #{e.message}"
+        shutdown
+        logger.info '[gruf] Stopped. Good-bye!'
+      end
+
       ##
       # Setup options for CLI execution and configure Gruf based on inputs
       #
-      def setup!
+      def setup_options!
         opts = parse_options
 
         Gruf.server_binding_url = opts[:host] if opts[:host]
@@ -114,6 +141,61 @@ module Gruf
           end
         end
       end
+
+      ##
+      # Setup Gruf
+      #
+      def setup!
+        @server ||= Gruf::Server.new(Gruf.server_options)
+        @hook_executor ||= Gruf::Hooks::Executor.new(hooks: Gruf.hooks&.prepare)
+
+        # wait to load controllers until last possible second to allow late configuration
+        ::Gruf.autoloaders.load!(controllers_path: Gruf.controllers_path)
+
+        setup_services
+      end
+
+      def setup_services
+        # allow lazy registering globally as late as possible, this allows more flexible binstub injections
+        @services = ::Gruf.services unless @services&.any?
+        unless @services.any? # rubocop:disable Lint/GuardClause
+          raise NoServicesBoundError,
+                'No services bound to this gruf process; please bind a service to a Gruf controller ' \
+                'to start the server successfully'
+        end
+      end
+
+      def wait_till_terminated
+        self_read = setup_signals
+
+        readable_io = IO.select([self_read]) # rubocop:disable Lint/IncompatibleIoSelectWithFiberScheduler
+        signal = readable_io.first[0].gets.strip
+        raise Interrupt, "SIG#{signal} received"
+      end
+
+      def setup_signals
+        self_read, self_write = IO.pipe
+
+        KILL_SIGNALS.each do |signal|
+          trap signal do
+            self_write.puts signal
+          end
+        end
+
+        self_read
+      end
+
+      ##
+      # Updates proc name/title
+      #
+      # @param [Symbol] state
+      #
+      # :nocov:
+      def update_proc_title(state)
+        Process.setproctitle("gruf #{Gruf::VERSION} -- #{state}")
+      end
+
+      # :nocov:
     end
   end
 end

--- a/lib/gruf/integrations/rails/railtie.rb
+++ b/lib/gruf/integrations/rails/railtie.rb
@@ -34,6 +34,14 @@ module Gruf
             end
           end
         end
+
+        # Since Rails 6.1
+        if respond_to?(:server)
+          server do
+            require 'gruf'
+            Gruf::Cli::Executor.embed!
+          end
+        end
       end
     end
   end

--- a/spec/gruf/server_spec.rb
+++ b/spec/gruf/server_spec.rb
@@ -28,17 +28,17 @@ describe Gruf::Server do
     ::Gruf.services = []
   end
 
-  describe '#start!' do
-    subject { gruf_server.start! }
+  describe '#start' do
+    subject { gruf_server.start }
 
     let(:server_mock) do
       double(
         GRPC::RpcServer,
         add_http2_port: nil,
-        run_till_terminated_or_interrupted: nil,
         run: nil,
         wait_till_running: nil,
         handle: nil,
+        running_state: :running,
         stopped?: true
       )
     end
@@ -76,20 +76,6 @@ describe Gruf::Server do
       it 'runs server with default configuration' do
         expect(GRPC::RpcServer).to receive(:new).with(**derived_options).and_return(server_mock)
         subject
-      end
-    end
-
-    context 'when TERM signal is received' do
-      it 'stops gracefully' do
-        server_thread = Thread.new do
-          srv = described_class.new
-          srv.add_service(::Rpc::ThingService::Service)
-          srv.start!
-        end
-        sleep 3 # wait for a server to boot up
-        Process.kill('TERM', Process.pid)
-        server_thread.join
-        expect(server_thread.status).to be false # expect thread to exit normally
       end
     end
   end
@@ -134,7 +120,7 @@ describe Gruf::Server do
 
     context 'when the server is already started' do
       before do
-        gruf_server.instance_variable_set(:@started, true)
+        allow(gruf_server).to receive(:running?).and_return(true)
       end
 
       it 'raises ServerAlreadyStartedError' do
@@ -163,7 +149,7 @@ describe Gruf::Server do
 
     context 'when the server is already started' do
       before do
-        gruf_server.instance_variable_set(:@started, true)
+        allow(gruf_server).to receive(:running?).and_return(true)
       end
 
       it 'raises ServerAlreadyStartedError' do
@@ -205,7 +191,7 @@ describe Gruf::Server do
 
     context 'when the server is already started' do
       before do
-        gruf_server.instance_variable_set(:@started, true)
+        allow(gruf_server).to receive(:running?).and_return(true)
       end
 
       it 'raises ServerAlreadyStartedError' do
@@ -234,7 +220,7 @@ describe Gruf::Server do
 
     context 'when the server is already started' do
       before do
-        gruf_server.instance_variable_set(:@started, true)
+        allow(gruf_server).to receive(:running?).and_return(true)
       end
 
       it 'raises ServerAlreadyStartedError' do
@@ -275,7 +261,7 @@ describe Gruf::Server do
 
     context 'when the server is already started' do
       before do
-        gruf_server.instance_variable_set(:@started, true)
+        allow(gruf_server).to receive(:running?).and_return(true)
       end
 
       it 'raises ServerAlreadyStartedError' do
@@ -301,7 +287,7 @@ describe Gruf::Server do
 
     context 'when the server is already started' do
       before do
-        gruf_server.instance_variable_set(:@started, true)
+        allow(gruf_server).to receive(:running?).and_return(true)
       end
 
       it 'raises ServerAlreadyStartedError' do


### PR DESCRIPTION
## What? Why?
Hi. I added integration with Rails(since 6.1) [based](https://github.com/anycable/anycable-rails/blob/master/lib/anycable/rails/railtie.rb#L63) on AnyCable. 
Now there is no need to call `bundle exec gruf`.
I had to change the structure of the startup logic a lot, but I hope I didn't break anything.

## How was it tested?
For testing, I used a demo project and tests.
