### PR TITLE
Add `context` hash attribute to `Gruf::Controllers::Request` to allow interceptors to pass information down to a gruf controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- [#163] Add `context` hash attribute to `Gruf::Controllers::Request` to allow interceptors to pass information down
+  to a gruf controller
+
 ### 2.15.1
 
 - Fix issue where GRPC_SERVER_POOL_KEEP_ALIVE and GRPC_SERVER_POLL_PERIOD when set via ENV are not cast to int

--- a/lib/gruf.rb
+++ b/lib/gruf.rb
@@ -17,6 +17,7 @@
 #
 require 'grpc'
 require 'active_support/core_ext/module/delegation'
+require 'active_support/hash_with_indifferent_access'
 require 'active_support/concern'
 require 'active_support/inflector'
 require 'base64'

--- a/lib/gruf/controllers/request.rb
+++ b/lib/gruf/controllers/request.rb
@@ -36,6 +36,11 @@ module Gruf
       # @!attribute [r] service
       #   @return [Class] The GRPC service class for this request
       attr_reader :service
+      # @!attribute [r] context
+      #   @return [::ActiveSupport::HashWithIndifferentAccess] An arbitrary hash of key/value entries that are
+      #     accessible for interceptors, that can be used to shared information between interceptors and pass down into
+      #     the controller.
+      attr_reader :context
 
       delegate :metadata, to: :active_call
       delegate :messages, :client_streamer?, :server_streamer?, :bidi_streamer?, :request_response?, to: :type
@@ -72,6 +77,7 @@ module Gruf
         @message = message
         @rpc_desc = rpc_desc
         @type = Type.new(rpc_desc)
+        @context = ::ActiveSupport::HashWithIndifferentAccess.new
       end
 
       ##

--- a/spec/gruf/controllers/request_spec.rb
+++ b/spec/gruf/controllers/request_spec.rb
@@ -113,6 +113,26 @@ describe ::Gruf::Controllers::Request do
     end
   end
 
+  describe '#context' do
+    subject { request.context }
+
+    it 'allows access to the context' do
+      expect(subject).to eq({})
+
+      subject[:foo] = 'bar'
+      expect(subject[:foo]).to eq 'bar'
+    end
+
+    it 'accesses values indifferently' do
+      subject[:foo] = 'bar'
+      expect(subject['foo']).to eq 'bar'
+
+      subject['foo'] = 'baz'
+      expect(subject['foo']).to eq 'baz'
+      expect(subject[:foo]).to eq 'baz'
+    end
+  end
+
   describe '#metadata' do
     subject { request.metadata }
 

--- a/spec/support/interceptors.rb
+++ b/spec/support/interceptors.rb
@@ -21,6 +21,11 @@
 ##########################################################################################
 class TestServerInterceptor < ::Gruf::Interceptors::ServerInterceptor
   def call
+    cs = options.fetch(:context_setting, nil)
+    if cs
+      request.context[:setting] = cs # shared key
+      request.context[:setting1] = cs
+    end
     Math.sqrt(4)
     yield
   end
@@ -28,6 +33,11 @@ end
 
 class TestServerInterceptor2 < ::Gruf::Interceptors::ServerInterceptor
   def call
+    cs = options.fetch(:context_setting, nil)
+    if cs
+      request.context[:setting] = cs # shared key
+      request.context[:setting2] = cs
+    end
     Math.sqrt(16)
     yield
   end


### PR DESCRIPTION
## What? Why?

Adds a `context` attribute to `Gruf::Controllers::Request` that allows Server Interceptors to pass information between each other and down to gruf controllers. Fixes #163.

## How was it tested?

rspec, e2e test, console