### PR TITLE
Add ability to serve default grpc health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+- Add opt-in ability to serve the official [gRPC health check](https://github.com/grpc/grpc/blob/master/src/ruby/pb/grpc/health/v1/health_services_pb.rb)
+  automatically via `health_check_enabled` configuration option (or `GRUF_HEALTH_CHECK_ENABLED` environment
+  variable).
+- Add `health_check_hook` configuration option to implement a custom response for the above gRPC built-in health check
 - [#156] Allow passing a specific list of services to run via the gruf binstub
 - [#163] Add `context` hash attribute to `Gruf::Controllers::Request` to allow interceptors to pass information down
   to a gruf controller

--- a/script/e2e
+++ b/script/e2e
@@ -26,6 +26,8 @@ ok "Running client streamer test..."
 bundle exec rake gruf:demo:create_things
 ok "Running bidi streamer test..."
 bundle exec rake gruf:demo:create_things_in_stream
+ok "Running health check test..."
+bundle exec rake gruf:demo:health_check
 
 ok "Tests successful! Shutting down server..."
 kill -9 $server_pid

--- a/spec/demo_server
+++ b/spec/demo_server
@@ -51,6 +51,7 @@ Gruf.configure do |c|
   c.server_binding_url = 'localhost:8001'
   c.error_serializer = Serializers::Proto
   c.backtrace_on_error = true
+  c.health_check_enabled = true
   c.interceptors.use(
     Gruf::Interceptors::Instrumentation::Statsd,
     client: FakeStats.new,

--- a/spec/gruf/controllers/health_controller_spec.rb
+++ b/spec/gruf/controllers/health_controller_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+describe ::Gruf::Controllers::HealthController do
+  let(:rpc_service) { ::Grpc::Health::V1::Health::Service }
+  let(:rpc_desc) { rpc_service.rpc_descs.values.first }
+  let(:message) { ::Grpc::Health::V1::HealthCheckRequest.new }
+  let(:controller) do
+    described_class.new(
+      method_key: :get_thing,
+      service: rpc_service,
+      active_call: Rpc::Test::Call.new,
+      message: message,
+      rpc_desc: rpc_desc
+    )
+  end
+
+  describe '#check' do
+    subject { controller.check }
+
+    let(:response) do
+      ::Grpc::Health::V1::HealthCheckResponse.new(
+        status: ::Grpc::Health::V1::HealthCheckResponse::ServingStatus::SERVING
+      )
+    end
+
+    context 'when Gruf.health_check_hook is nil' do
+      it 'returns a serving response' do
+        expect(subject).to eq response
+      end
+    end
+
+    context 'when Gruf.health_check_hook responds to call' do
+      before do
+        Gruf.health_check_hook = lambda do |_request, _error|
+          Math.sqrt(4)
+          response
+        end
+      end
+
+      it 'returns a health check response, calling the proc instead' do
+        expect(Math).to receive(:sqrt).with(4).once
+        expect(subject).to eq response
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What? Why?

Adds the ability to serve the default gRPC health check class as a gruf controller automatically. This can be triggered via:
- ENV `GRUF_HEALTH_CHECK_ENABLED=1`
- `Gruf.health_check_enabled = true` in configuration
- `--health-check` CLI argument

Note that all of these default to **off** by default to prevent any regressions on upgrades for apps that may already be serving a health check.

This will bind a `Gruf::Controllers::HealthController` to the running process automatically. The health controller's `check` method will simply return a `SERVING` `::Grpc::Health::V1::HealthCheckResponse` response object.

Secondly, this PR adds a `Gruf.health_check_hook` option, that can be used to provide a custom health check response:

```ruby
Gruf.health_check_hook = lambda do |_request, _error|
  status = determine_status_some_other_way
  ::Grpc::Health::V1::HealthCheckResponse.new(status: status)
end
```

When a proc (or compatible object that responds to `.call`) is passed this way, it will use the result of that call to determine the response of the health check. This allows serving a custom health check without having to create the entire gruf controller in each app.

## How was it tested?

rspec, manually. Also added a full end-to-end test to the e2e suite. You can test yourself by running `LOG_LEVEL=debug spec/demo_server` and then running `bundle exec rake gruf:demo:health_check` in a separate terminal.
