### PR TITLE
fix a code reload  concurency issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+* [#175] Fix code reload threadsafety. Calls to `Zeitwerk::Loader#setup` should be made in a thread-safe manner.
+
 ### 2.16.1
 
 * Fix issue where default gRPC health check was loaded even if unused or not desired; now only loaded when requested

--- a/lib/gruf/controllers/autoloader.rb
+++ b/lib/gruf/controllers/autoloader.rb
@@ -47,7 +47,11 @@ module Gruf
       # Reload all files managed by the autoloader, if reloading is enabled
       #
       def reload
-        @loader.reload if @reloading_enabled
+        if @reloading_enabled
+          reload_mutex do
+            @loader.reload
+          end
+        end
       end
 
       private
@@ -68,6 +72,17 @@ module Gruf
         # to the gRPC Service classes
         @loader.eager_load
         @setup = true
+      end
+
+      ##
+      # Handle thread-safe access to the loader
+      #
+      def reload_mutex(&block)
+        @reload_mutex ||= begin
+          require 'monitor'
+          Monitor.new
+        end
+        @reload_mutex.synchronize(&block)
       end
     end
   end

--- a/spec/gruf/controllers/autoloader_spec.rb
+++ b/spec/gruf/controllers/autoloader_spec.rb
@@ -101,6 +101,15 @@ describe ::Gruf::Controllers::Autoloader do
         expect(zeitwerk).to receive(:reload).once
         subject
       end
+
+      it 'accesses the loader in a thread-safe manner' do
+        autoloader.send(:reload_mutex) { true }
+        expect(autoloader.instance_variable_get(:@reload_mutex)).to receive(:synchronize).and_yield.twice
+        threads = []
+        threads << Thread.new { autoloader.reload }
+        threads << Thread.new { autoloader.reload }
+        threads.each(&:join)
+      end
     end
 
     context 'when code reloading is disabled' do


### PR DESCRIPTION
## What? Why?

I started getting the following error:

```
[GRPC] app err:#<GRPC::ActiveCall:0x000000011501e260>, status:13:please, finish your configuration and call Zeitwerk::Loader#setup once all is ready
```

When Zeitwerk does a `reload` ([here](https://github.com/fxn/zeitwerk/blob/4d88e4ffeef65bdedc5077deae59e729b25a6c34/lib/zeitwerk/loader.rb#L219-L227)), it "un-setups" (`#unload`) itself before a rebuild of itself (`#setup`). But it's not thread-safe so if two threads get in there, if the second one hits reload before the first has finished to re-setup. Then it's going to detect that setup hasn't run and throw the ` finish your configuration and call Zeitwerk::Loader#setup` error.

I think i started getting this after the following gem udpate(?):

```
google-protobuf (3.21.9)
grpc (1.50.0)
grpc-tools (1.50.0)
```

Maybe there were changes in concurency in those gems. Maybe it's something else, got lots of changes merging on this repo. But it fixed my app so I'm using this for now.

## How was it tested?

my local app consistently failed. my local app now consistently works.
