### PR TITLE
Fix RSpec/FactoryBot/ConsistentParenthesesStyle cop in tests

### DIFF
--- a/spec/gruf/interceptors/active_record/connection_reset_spec.rb
+++ b/spec/gruf/interceptors/active_record/connection_reset_spec.rb
@@ -18,8 +18,8 @@
 require 'spec_helper'
 
 describe Gruf::Interceptors::ActiveRecord::ConnectionReset do
-  let(:request) { build :controller_request }
-  let(:errors) { build :error }
+  let(:request) { build(:controller_request) }
+  let(:errors) { build(:error) }
   let(:interceptor) { described_class.new(request, errors) }
 
   describe '#call' do

--- a/spec/gruf/interceptors/authentication/basic_spec.rb
+++ b/spec/gruf/interceptors/authentication/basic_spec.rb
@@ -43,8 +43,8 @@ describe Gruf::Interceptors::Authentication::Basic do
 
   let(:metadata) { { :authorization.to_s => request_credentials } }
   let(:active_call) { double(:active_call, metadata: metadata) }
-  let(:request) { build :controller_request, active_call: active_call }
-  let(:errors) { build :error }
+  let(:request) { build(:controller_request, active_call: active_call) }
+  let(:errors) { build(:error) }
   let(:interceptor) do
     described_class.new(
       request,

--- a/spec/gruf/interceptors/context_spec.rb
+++ b/spec/gruf/interceptors/context_spec.rb
@@ -22,8 +22,8 @@ describe Gruf::Interceptors::Context do
   let(:interceptors) do
     [interceptor_class.new(request, errors)]
   end
-  let(:request) { build :controller_request }
-  let(:errors) { build :error }
+  let(:request) { build(:controller_request) }
+  let(:errors) { build(:error) }
   let(:interceptor_context) { described_class.new(interceptors) }
 
   describe '#intercept!' do

--- a/spec/gruf/interceptors/instrumentation/output_metadata_timer_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/output_metadata_timer_spec.rb
@@ -19,8 +19,8 @@ require 'spec_helper'
 
 describe Gruf::Interceptors::Instrumentation::OutputMetadataTimer do
   let(:options) { { metadata_key: :timer } }
-  let(:request) { build :controller_request, method_key: :get_thing }
-  let(:errors) { build :error }
+  let(:request) { build(:controller_request, method_key: :get_thing) }
+  let(:errors) { build(:error) }
   let(:interceptor) { described_class.new(request, errors, options) }
 
   describe '#call' do

--- a/spec/gruf/interceptors/instrumentation/request_logging/formatters/base_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/formatters/base_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 
 describe Gruf::Interceptors::Instrumentation::RequestLogging::Formatters::Base do
   let(:formatter) { described_class.new }
-  let(:request) { build :controller_request }
+  let(:request) { build(:controller_request) }
   let(:result) { Gruf::Interceptors::Timer.time { Rpc::GetThingResponse.new } }
   let(:payload) { {} }
 

--- a/spec/gruf/interceptors/instrumentation/request_logging/formatters/logstash_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/formatters/logstash_spec.rb
@@ -19,7 +19,7 @@ require 'spec_helper'
 
 describe Gruf::Interceptors::Instrumentation::RequestLogging::Formatters::Logstash do
   let(:formatter) { described_class.new }
-  let(:request) { build :controller_request }
+  let(:request) { build(:controller_request) }
   let(:result) { Gruf::Interceptors::Timer.time { Rpc::GetThingResponse.new } }
   let(:payload) { { message: 'foo', params: { one: 2 } } }
 

--- a/spec/gruf/interceptors/instrumentation/request_logging/formatters/plain_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/formatters/plain_spec.rb
@@ -24,7 +24,7 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Formatters::Plain 
   let(:execution_time) { 0.001 }
   let(:message) { 'foo' }
   let(:params) { { id: 1 } }
-  let(:request) { build :controller_request }
+  let(:request) { build(:controller_request) }
   let(:result) { Gruf::Interceptors::Timer.time { Rpc::GetThingResponse.new } }
   let(:payload) { { message: message, status: status, method: route_key, duration: execution_time, params: params } }
 

--- a/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
@@ -30,8 +30,8 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
   let(:execution_time) { rand(0.001..10.000).to_f }
   let(:call_signature) { :get_thing_without_intercept }
 
-  let(:controller_request) { build :controller_request, method_key: :get_thing }
-  let(:errors) { build :error }
+  let(:controller_request) { build(:controller_request, method_key: :get_thing) }
+  let(:errors) { build(:error) }
   let(:interceptor) { described_class.new(controller_request, errors, options) }
   let(:call) { interceptor.call { true } }
   let(:logger) { ::Logger.new(File::NULL) }

--- a/spec/gruf/interceptors/instrumentation/statsd_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/statsd_spec.rb
@@ -22,8 +22,8 @@ describe Gruf::Interceptors::Instrumentation::Statsd do
   let(:client) { double(:statsd, increment: true, timing: true) }
   let(:prefix) { 'app' }
 
-  let(:request) { build :controller_request, method_key: :get_thing }
-  let(:errors) { build :error }
+  let(:request) { build(:controller_request, method_key: :get_thing) }
+  let(:errors) { build(:error) }
   let(:interceptor) { described_class.new(request, errors, options) }
 
   let(:expected_route_key) { "#{prefix ? "#{prefix}." : ''}rpc.thing_service.get_thing" }

--- a/spec/gruf/interceptors/registry_spec.rb
+++ b/spec/gruf/interceptors/registry_spec.rb
@@ -175,8 +175,8 @@ describe Gruf::Interceptors::Registry do
   describe '#prepare' do
     subject { registry.prepare(request, errors) }
 
-    let(:request) { build :controller_request }
-    let(:errors) { build :error }
+    let(:request) { build(:controller_request) }
+    let(:errors) { build(:error) }
 
     before do
       registry.use(interceptor_class)

--- a/spec/gruf/interceptors/server_interceptor_spec.rb
+++ b/spec/gruf/interceptors/server_interceptor_spec.rb
@@ -37,8 +37,8 @@ describe Gruf::Interceptors::ServerInterceptor do
   describe '#call' do
     subject { interceptor.new(request, error, {}).call }
 
-    let(:request) { build :controller_request }
-    let(:error) { build :error }
+    let(:request) { build(:controller_request) }
+    let(:error) { build(:error) }
 
     context 'when it is not extended' do
       let(:interceptor) { described_class }


### PR DESCRIPTION
## What? Why?

Fixes tests so rubocop cop `RSpec/FactoryBot/ConsistentParenthesesStyle` passes in main.

## How was it tested?

`bundle exec rubocop -P`