### PR TITLE
Fix Style/GuardClause cop in autoloader

### DIFF
--- a/lib/gruf/controllers/autoloader.rb
+++ b/lib/gruf/controllers/autoloader.rb
@@ -47,10 +47,10 @@ module Gruf
       # Reload all files managed by the autoloader, if reloading is enabled
       #
       def reload
-        if @reloading_enabled
-          reload_mutex do
-            @loader.reload
-          end
+        return unless @reloading_enabled
+
+        reload_mutex do
+          @loader.reload
         end
       end
 


### PR DESCRIPTION
## What? Why?

Just some code style tidying in the autoloader to make Rubocop happy.

## How was it tested?

`bundle exec rubocop -P`
