### PR TITLE
Introduce read-write lock for code reloading; do code reloading before controller name resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+* [#178] Introduce read-write lock for code reloading; cover controller class resolution with code reloading.
 * [#180] Support multiple databases connection reset in `Gruf::Interceptors::ActiveRecord::ConnectionReset`.
 
 ### 2.16.2

--- a/lib/gruf/controllers/autoloader.rb
+++ b/lib/gruf/controllers/autoloader.rb
@@ -57,10 +57,11 @@ module Gruf
       end
 
       def with_fresh_controller(controller_name)
-        Gruf::Autoloaders.reload
+        return yield(controller_name.constantize) unless @reloading_enabled
+
+        ::Gruf::Autoloaders.reload
         reload_lock.with_read_lock do
-          controller = controller_name.constantize
-          yield controller
+          yield(controller_name.constantize)
         end
       end
 

--- a/lib/gruf/controllers/base.rb
+++ b/lib/gruf/controllers/base.rb
@@ -90,7 +90,6 @@ module Gruf
       # @param [block] &block The passed block for executing the method
       #
       def call(method_key, &block)
-        ::Gruf.autoloaders.reload if ::Gruf.development?
         Interceptors::Context.new(@interceptors).intercept! do
           process_action(method_key, &block)
         end

--- a/lib/gruf/controllers/service_binder.rb
+++ b/lib/gruf/controllers/service_binder.rb
@@ -50,8 +50,8 @@ module Gruf
           service_ref.class_eval do
             if desc.request_response?
               define_method(method_key) do |message, active_call|
-                Gruf::Autoloaders.controllers.with_fresh_controller(controller_name) do |controller|
-                  c = controller.new(
+                Gruf::Autoloaders.controllers.with_fresh_controller(controller_name) do |fresh_controller|
+                  c = fresh_controller.new(
                     method_key: method_key,
                     service: service_ref,
                     message: message,
@@ -63,8 +63,8 @@ module Gruf
               end
             elsif desc.client_streamer?
               define_method(method_key) do |active_call|
-                Gruf::Autoloaders.controllers.with_fresh_controller(controller_name) do |controller|
-                  c = controller.new(
+                Gruf::Autoloaders.controllers.with_fresh_controller(controller_name) do |fresh_controller|
+                  c = fresh_controller.new(
                     method_key: method_key,
                     service: service_ref,
                     message: proc { |&block| active_call.each_remote_read(&block) },
@@ -76,8 +76,8 @@ module Gruf
               end
             elsif desc.server_streamer?
               define_method(method_key) do |message, active_call, &block|
-                Gruf::Autoloaders.controllers.with_fresh_controller(controller_name) do |controller|
-                  c = controller.new(
+                Gruf::Autoloaders.controllers.with_fresh_controller(controller_name) do |fresh_controller|
+                  c = fresh_controller.new(
                     method_key: method_key,
                     service: service_ref,
                     message: message,
@@ -89,8 +89,8 @@ module Gruf
               end
             else # bidi
               define_method(method_key) do |messages, active_call, &block|
-                Gruf::Autoloaders.controllers.with_fresh_controller(controller_name) do |controller|
-                  c = controller.new(
+                Gruf::Autoloaders.controllers.with_fresh_controller(controller_name) do |fresh_controller|
+                  c = fresh_controller.new(
                     method_key: method_key,
                     service: service_ref,
                     message: messages,

--- a/spec/gruf/controllers/autoloader_spec.rb
+++ b/spec/gruf/controllers/autoloader_spec.rb
@@ -103,8 +103,8 @@ describe ::Gruf::Controllers::Autoloader do
       end
 
       it 'accesses the loader in a thread-safe manner' do
-        autoloader.send(:reload_mutex) { true }
-        expect(autoloader.instance_variable_get(:@reload_mutex)).to receive(:synchronize).and_yield.twice
+        autoloader.send(:reload_lock)
+        expect(autoloader.instance_variable_get(:@reload_lock)).to receive(:with_write_lock).and_yield.twice
         threads = []
         threads << Thread.new { autoloader.reload }
         threads << Thread.new { autoloader.reload }

--- a/spec/gruf/controllers/base_spec.rb
+++ b/spec/gruf/controllers/base_spec.rb
@@ -60,28 +60,6 @@ describe ::Gruf::Controllers::Base do
       expect(subject).to be_a(Rpc::GetThingResponse)
     end
 
-    context 'when in development' do
-      before do
-        allow(::Gruf).to receive(:development?).and_return(true)
-      end
-
-      it 'reloads the autoloaders' do
-        expect(Gruf.autoloaders).to receive(:reload)
-        subject
-      end
-    end
-
-    context 'when not in development' do
-      before do
-        allow(::Gruf).to receive(:development?).and_return(false)
-      end
-
-      it 'does not reload the autoloaders' do
-        expect(Gruf.autoloaders).not_to receive(:reload)
-        subject
-      end
-    end
-
     context 'when there are interceptors' do
       it 'passes the request to interceptors' do
         Gruf.interceptors.use(TestServerInterceptor)

--- a/spec/gruf/functional/server_spec.rb
+++ b/spec/gruf/functional/server_spec.rb
@@ -83,4 +83,30 @@ describe 'Functional server test' do
       end
     end
   end
+
+  describe 'code reloading', :run_thing_server do
+    subject { build_client.call(:GetThing, id: 1) }
+
+    context 'when in development' do
+      before do
+        allow(Gruf).to receive(:development?).and_return(true)
+      end
+
+      it 'reloads the autoloaders' do
+        expect(Gruf.autoloaders).to receive(:reload)
+        subject
+      end
+    end
+
+    context 'when not in development' do
+      before do
+        allow(Gruf).to receive(:development?).and_return(false)
+      end
+
+      it 'does not reload the autoloaders' do
+        expect(Gruf.autoloaders).not_to receive(:reload)
+        subject
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What? Why?

- Fixes https://github.com/bigcommerce/gruf/issues/174 (at least, for us)
- Zeitwerk suggests [using a read-write lock for code reloading](https://github.com/fxn/zeitwerk#thread-safety), so that reloading cannot happen during a parallel request. 
- Moved code reloading to happen _before_ the controller is constantized, because otherwise you get a stale class and it doesn't work with reloading included modules.
- Or, rather, now it _wraps_ the entire service method call, first reloads the code if necessary, then locks for read access
- In production mode the write lock will never be acquired, and the read lock will simply let code through.

## How was it tested?

- Added tests, plus errors described in #174 went away on my machine. 