### PR TITLE
Support multiple databases connection reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+* [#180] Support multiple databases connection reset in `Gruf::Interceptors::ActiveRecord::ConnectionReset`.
+
 ### 2.16.2
 
 * [#175] Fix code reload thread-safety. Calls to `Zeitwerk::Loader#setup` are now made in a thread-safe manner.

--- a/lib/gruf/interceptors/active_record/connection_reset.rb
+++ b/lib/gruf/interceptors/active_record/connection_reset.rb
@@ -27,11 +27,13 @@ module Gruf
         # connection pool, we need to ensure that this is done to properly
         #
         def call
-          ::ActiveRecord::Base.establish_connection if enabled? && !::ActiveRecord::Base.connection.active?
+          if enabled?
+            target_classes.each { |klass| klass.establish_connection unless klass.connection.active? }
+          end
 
           yield
         ensure
-          ::ActiveRecord::Base.clear_active_connections! if enabled?
+          target_classes.each(&:clear_active_connections!) if enabled?
         end
 
         private
@@ -41,6 +43,13 @@ module Gruf
         #
         def enabled?
           defined?(::ActiveRecord::Base)
+        end
+
+        ##
+        # @return [Array<Class>] The list of ActiveRecord classes to reset
+        #
+        def target_classes
+          options[:target_classes] || [::ActiveRecord::Base]
         end
       end
     end

--- a/spec/gruf/interceptors/active_record/connection_reset_spec.rb
+++ b/spec/gruf/interceptors/active_record/connection_reset_spec.rb
@@ -20,7 +20,9 @@ require 'spec_helper'
 describe Gruf::Interceptors::ActiveRecord::ConnectionReset do
   let(:request) { build(:controller_request) }
   let(:errors) { build(:error) }
-  let(:interceptor) { described_class.new(request, errors) }
+  let(:animals_record) { Class.new(::ActiveRecord::Base) }
+  let(:target_classes) { [animals_record, ::ActiveRecord::Base] }
+  let(:interceptor) { described_class.new(request, errors, { target_classes: target_classes }) }
 
   describe '#call' do
     subject { interceptor.call { true } }
@@ -31,8 +33,10 @@ describe Gruf::Interceptors::ActiveRecord::ConnectionReset do
       end
 
       it 'tries to clear any active connections' do
-        expect(::ActiveRecord::Base).to receive(:establish_connection).and_call_original
-        expect(::ActiveRecord::Base).to receive(:clear_active_connections!).and_call_original
+        expect(animals_record).to receive(:establish_connection).and_call_original
+        expect(animals_record).to receive(:clear_active_connections!).and_call_original
+        expect(::ActiveRecord::Base).to receive(:establish_connection)
+        expect(::ActiveRecord::Base).to receive(:clear_active_connections!)
         subject
       end
     end
@@ -45,6 +49,8 @@ describe Gruf::Interceptors::ActiveRecord::ConnectionReset do
       it 'does not try to clear any active connections' do
         expect(::ActiveRecord::Base).not_to receive(:establish_connection)
         expect(::ActiveRecord::Base).not_to receive(:clear_active_connections!)
+        expect(animals_record).not_to receive(:establish_connection)
+        expect(animals_record).not_to receive(:clear_active_connections!)
         subject
       end
     end


### PR DESCRIPTION
## What? Why?
- This PR support multiple databases connection reset
- In our company, we use multiple databases like below.

```yaml
production:
  primary:
    database: my_primary_database
    username: root
    password: <%= ENV['ROOT_PASSWORD'] %>
    adapter: mysql2
  animals:
    database: my_animals_database
    username: animals_root
    password: <%= ENV['ANIMALS_ROOT_PASSWORD'] %>
    adapter: mysql2
    migrations_paths: db/animals_migrate
```

```ruby
class AnimalsRecord < ApplicationRecord
  self.abstract_class = true

  connects_to database: { writing: :animals }
end
```
(Copied from https://guides.rubyonrails.org/active_record_multiple_databases.html)

We use basic `Gruf::Interceptors::ActiveRecord::ConnectionReset` but there was connection pool error. After some debug, we discovered that it was a problem about our non-primary database, `AnimalsRecord` in above example. 

I think it's better to support this feature in upstream. So, I make a PR for it. 😄 

## How was it tested?
- My company uses it's hard-coded version (which replace `target_classes` to our `ApplicationRecord`'s subclasses) in our production deployment.
- I made some test cases.

---

Thanks for this Gem. I love it ❤️ 