### PR TITLE
Various fixes for latest rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,16 +57,12 @@ Metrics/BlockLength:
 Lint/UnusedMethodArgument:
   AllowUnusedKeywordArguments: true
 
-# This cop also affects hash keys, which is bad as we can't always control that. Disabling.
-Naming/VariableNumber:
-  Enabled: false
-
 # We're fine with this
 ThreadSafety/NewThread:
   Enabled: false
 
-# Not necessary
-Layout/EmptyLineBetweenDefs:
+# We prefer the leading constant declaration for easier refactoring
+Style/RedundantConstantBase:
   Enabled: false
 
 ####################################################################################################

--- a/spec/gruf/logging_spec.rb
+++ b/spec/gruf/logging_spec.rb
@@ -20,6 +20,7 @@ require 'spec_helper'
 class TestLogging
   include Gruf::Logger
 end
+
 class TestGrpcLogging
   include Gruf::GrpcLogger
 end


### PR DESCRIPTION
## What? Why?

* Various fixes for latest rubocop so test suites pass
* Ignore `Style/RedundantConstantBase` as we prefer prefixing to allow safety in refactoring

## How was it tested?

rspec, this PR