### PR TITLE
Add Ruby 3.2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,12 @@ executors:
       ruby-version:
         type: string
         default: "3.1"
+  ruby_3_2:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.2"
 
 commands:
   pre-setup:
@@ -217,3 +223,18 @@ workflows:
       - e2e:
           name: "ruby-3_1-e2e"
           e: "ruby_3_1"
+  ruby_3_2:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_2-bundle_audit"
+          e: "ruby_3_2"
+      - rubocop:
+          name: "ruby-3_2-rubocop"
+          e: "ruby_3_2"
+      - rspec-unit:
+          name: "ruby-3_2-rspec"
+          e: "ruby_3_2"
+          code-climate: false
+      - e2e:
+          name: "ruby-3_2-e2e"
+          e: "ruby_3_2"

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'gruf'
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7', '< 3.2'
+  spec.required_ruby_version = '>= 2.7', '< 3.3'
 
   spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/bigcommerce/gruf/issues',


### PR DESCRIPTION
## What? Why?

(This is an updated version of #179) Adds Ruby 3.2 support, updates CCI suite, and README.

FWIW - I tested this with a YJIT-enabled Ruby, and `RUBYOPT='--enable-yjit'` set, and the e2e suite worked as expected.

## How was it tested?

As grpc does not yet support arm macs, you'll need to run `bundle config build.grpc --with-ldflags="-Wl,-undefined,dynamic_lookup"` before bundle installing. This will be added to the wiki when this is merged.
