### PR TITLE
Dynamically determine use_default_interceptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+* Add `GRUF_USE_DEFAULT_INTERCEPTORS` ENV to dynamically enable/disable default interceptors
+
 ### 2.17.0
 
 * [#179] Add Ruby 3.2 support

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -188,7 +188,7 @@ module Gruf
       }
       self.use_default_interceptors = ::ENV.fetch('GRUF_USE_DEFAULT_INTERCEPTORS', 1).to_i.positive?
 
-      if self.use_default_interceptors
+      if use_default_interceptors
         interceptors.use(::Gruf::Interceptors::ActiveRecord::ConnectionReset)
         interceptors.use(::Gruf::Interceptors::Instrumentation::OutputMetadataTimer)
       end

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -186,7 +186,9 @@ module Gruf
         connect_md_proc: nil,
         server_args: {}
       }
-      if use_default_interceptors
+      self.use_default_interceptors = ::ENV.fetch('GRUF_USE_DEFAULT_INTERCEPTORS', 1).to_i.positive?
+
+      if self.use_default_interceptors
         interceptors.use(::Gruf::Interceptors::ActiveRecord::ConnectionReset)
         interceptors.use(::Gruf::Interceptors::Instrumentation::OutputMetadataTimer)
       end


### PR DESCRIPTION
## What? Why?
- I want to disable default interceptors 
- But `use_default_interceptors`'s default value is `true` so there are always default interceptor after `Configuration#reset` is called.
- To fix that behavior, add `GRUF_USE_DEFAULT_INTERCEPTORS` ENV to dynamically enable/disable default interceptors

## How was it tested?
- From local fork 😄 

