### PR TITLE
Fix supported Ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ up fast and efficiently at scale. Some of its features include:
   still preserving gRPC BadStatus codes
 * Server and client execution timings in responses
 
-gruf currently has active support for gRPC 1.10.x+. gruf is compatible and tested with Ruby 2.6-3.2.
+gruf currently has active support for gRPC 1.10.x+. gruf is compatible and tested with Ruby 2.7-3.2.
 gruf is also not [Rails](https://github.com/rails/rails)-specific, and can be used in any Ruby framework
 (such as [Grape](https://github.com/ruby-grape/grape) or [dry-rb](https://dry-rb.org/), for instance).
 


### PR DESCRIPTION
## What? Why?

Because this gem hasn't supported Ruby 2.6 since #165.

## How was it tested?

Document change only.
