### PR TITLE
Fix Rubocop violations

### DIFF
--- a/spec/gruf/error_spec.rb
+++ b/spec/gruf/error_spec.rb
@@ -145,7 +145,7 @@ describe Gruf::Error do
     let(:id) { 1 }
 
     context 'with a call that returns a field error' do
-      it 'raises a Gruf::Client::Error and return the unserialized error object', run_thing_server: true do
+      it 'raises a Gruf::Client::Error and return the unserialized error object', :run_thing_server do
         client = build_client
         expect do
           resp = client.call(:GetContextualFieldErrorFail, id: 1)
@@ -160,7 +160,7 @@ describe Gruf::Error do
     end
 
     context 'with multiple calls, where the first returns a field error, the second does not' do
-      it 'does not raise a Gruf::Client::Error the second time', run_thing_server: true do
+      it 'does not raise a Gruf::Client::Error the second time', :run_thing_server do
         client = build_client
         expect do
           client.call(:GetContextualFieldErrorFail, id: 1)
@@ -174,7 +174,7 @@ describe Gruf::Error do
     end
 
     context 'with multiple calls, with multiple having field errors' do
-      it 'does not aggregate errors across calls', run_thing_server: true do
+      it 'does not aggregate errors across calls', :run_thing_server do
         ts = []
         10.times do
           ts << Thread.new do
@@ -198,7 +198,7 @@ describe Gruf::Error do
     end
 
     context 'with a call that returns no errors' do
-      it 'raises no errors', run_thing_server: true do
+      it 'raises no errors', :run_thing_server do
         client = build_client
         expect do
           resp = client.call(:GetThing, id: 1)
@@ -209,7 +209,7 @@ describe Gruf::Error do
   end
 
   context 'with a call that raises an exception' do
-    it 'fails with an internal error message', run_thing_server: true do
+    it 'fails with an internal error message', :run_thing_server do
       client = build_client
       expect do
         resp = client.call(:GetException, id: 1)

--- a/spec/gruf/functional/interception_spec.rb
+++ b/spec/gruf/functional/interception_spec.rb
@@ -27,7 +27,7 @@ describe 'Functional interceptors test' do
 
   context 'when there is an interceptor added' do
     context 'with a request/response call' do
-      it 'intercepts the call', run_thing_server: true do
+      it 'intercepts the call', :run_thing_server do
         expect_any_instance_of(interceptor_class).to receive(:call).once.and_call_original
         client = build_client
         resp = client.call(:GetThing)
@@ -36,7 +36,7 @@ describe 'Functional interceptors test' do
     end
 
     context 'with a server streamer call' do
-      it 'intercepts the call', run_thing_server: true do
+      it 'intercepts the call', :run_thing_server do
         expect_any_instance_of(interceptor_class).to receive(:call).and_call_original
         client = build_client
         resp = client.call(:GetThings)
@@ -48,7 +48,7 @@ describe 'Functional interceptors test' do
     end
 
     context 'with a client streamer call' do
-      it 'intercepts the call', run_thing_server: true do
+      it 'intercepts the call', :run_thing_server do
         expect_any_instance_of(interceptor_class).to receive(:call).and_call_original
 
         things = []
@@ -67,7 +67,7 @@ describe 'Functional interceptors test' do
     end
 
     context 'with a bidi streamer call' do
-      it 'intercepts the call', run_thing_server: true do
+      it 'intercepts the call', :run_thing_server do
         expect_any_instance_of(interceptor_class).to receive(:call).and_call_original
         things = []
         5.times do

--- a/spec/gruf/functional/server_spec.rb
+++ b/spec/gruf/functional/server_spec.rb
@@ -32,7 +32,7 @@ describe 'Functional server test' do
     context 'when it is a request/response call' do
       let(:id) { 1 }
 
-      it 'returns the thing', run_thing_server: true do
+      it 'returns the thing', :run_thing_server do
         client = build_client
         resp = client.call(:GetThing, id: id)
         expect(resp.message).to be_a(Rpc::GetThingResponse)
@@ -42,7 +42,7 @@ describe 'Functional server test' do
     end
 
     context 'when it is a server streaming call' do
-      it 'returns the things in a stream from the server', run_thing_server: true do
+      it 'returns the things in a stream from the server', :run_thing_server do
         client = build_client
         resp = client.call(:GetThings)
         resp.message do |m|
@@ -52,7 +52,7 @@ describe 'Functional server test' do
     end
 
     context 'when it is a client streaming call' do
-      it 'returns the things from the server', run_thing_server: true do
+      it 'returns the things from the server', :run_thing_server do
         things = []
         5.times do
           things << Rpc::Thing.new(
@@ -68,7 +68,7 @@ describe 'Functional server test' do
     end
 
     context 'when it is a bidi streaming call' do
-      it 'returns the things from the server', run_thing_server: true do
+      it 'returns the things from the server', :run_thing_server do
         things = []
         5.times do
           things << Rpc::Thing.new(

--- a/spec/gruf/interceptors/server_interceptor_spec.rb
+++ b/spec/gruf/interceptors/server_interceptor_spec.rb
@@ -25,7 +25,7 @@ describe Gruf::Interceptors::ServerInterceptor do
   describe 'statelessness' do
     let(:interceptor) { TestServerInterceptorInstanceVar }
 
-    it 'does not persist interceptor instance variables across requests', run_thing_server: true do
+    it 'does not persist interceptor instance variables across requests', :run_thing_server do
       client = build_client
       resp = client.call(:GetThing)
       expect(resp.message).to be_a(Rpc::GetThingResponse)

--- a/spec/gruf/synchronized_client_spec.rb
+++ b/spec/gruf/synchronized_client_spec.rb
@@ -18,7 +18,7 @@
 require 'spec_helper'
 require 'thwait'
 
-describe Gruf::SynchronizedClient, run_thing_server: true do
+describe Gruf::SynchronizedClient, :run_thing_server do
   subject { build_sync_client(options) }
 
   let(:options) { {} }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,7 +41,7 @@ RSpec.configure do |config|
       Gruf.grpc_logger = Logger.new(File::NULL)
     end
   end
-  config.around(:example, run_thing_server: true) do |t|
+  config.around(:example, :run_thing_server) do |t|
     @server = build_server
     run_server(@server) do
       t.run


### PR DESCRIPTION
## What? Why?

This fixes `RSpec/MetadataStyle` violations by auto-correct. 

Ref: https://app.circleci.com/pipelines/github/bigcommerce/gruf/281/workflows/c3ea9b12-7d82-4ff4-814f-ab593b629bb8/jobs/3296?invite=true#step-106-117_74

The `MetadataStyle` has been added by 2.24.0. 
https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md#2241-2023-09-23

## How was it tested?

