### PR TITLE
Fix runtime dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+* [#190] Remove unsued `e2mmap` and `thwait` gems from `runtime_dependency`.
+
 ### 2.19.0
 
 * [#197] Add support for Ruby 3.3

--- a/Gemfile
+++ b/Gemfile
@@ -31,5 +31,6 @@ gem 'rubocop-performance', '>= 0.0.1'
 gem 'rubocop-rspec', '>= 2.0'
 gem 'rubocop-thread_safety', '>= 0.3'
 gem 'simplecov', '>= 0.16'
+gem 'thwait', '>= 0.1'
 
 gemspec

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -50,6 +50,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'grpc-tools', '~> 1.10'
   spec.add_runtime_dependency 'json', '>= 2.3'
   spec.add_runtime_dependency 'slop', '>= 4.6'
-  spec.add_runtime_dependency 'thwait', '>= 0.1'
   spec.add_runtime_dependency 'zeitwerk', '>= 2'
 end

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -45,7 +45,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport', '> 4'
   spec.add_runtime_dependency 'concurrent-ruby', '> 1'
-  spec.add_runtime_dependency 'e2mmap', '>= 0.1'
   spec.add_runtime_dependency 'grpc', '~> 1.10'
   spec.add_runtime_dependency 'grpc-tools', '~> 1.10'
   spec.add_runtime_dependency 'json', '>= 2.3'


### PR DESCRIPTION
## What? Why?

It seems that unsued gems are defined in `runtime_dependency`. This PR did the following.

* Remove `thwait` from `runtime_dependency` which is only used in tests.

```bash
$ git grep thwait
Gemfile:gem 'thwait', '>= 0.1'
spec/gruf/synchronized_client_spec.rb:require 'thwait'
```

* Remove `e2mmap` from `runtime_dependency`. This gem was added by f157736,  but it seems isn't used now.


## How was it tested?

I confirmed that the specs are passed.
