### PR TITLE
#191. Allow passing of request object directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 ### Pending release
 
 * Add `GRUF_USE_DEFAULT_INTERCEPTORS` ENV to dynamically enable/disable default interceptors
+* Allow passing of request object directly into `call`
 
 ### 2.17.0
 

--- a/lib/gruf/client.rb
+++ b/lib/gruf/client.rb
@@ -81,7 +81,11 @@ module Gruf
     #
     def call(request_method, params = {}, metadata = {}, opts = {}, &block)
       request_method = request_method.to_sym
-      req = streaming_request?(request_method) ? params : request_object(request_method, params)
+      req = if params.respond_to?(:to_proto) || streaming_request?(request_method)
+              params
+            else
+              request_object(request_method, params)
+            end
       md = build_metadata(metadata)
       call_sig = call_signature(request_method)
 

--- a/spec/gruf/client_spec.rb
+++ b/spec/gruf/client_spec.rb
@@ -232,6 +232,21 @@ describe Gruf::Client do
         expect { subject }.to raise_error(NotImplementedError)
       end
     end
+
+    context 'when passing the request directly' do
+      subject { client.call(method_name, req, metadata, opts) }
+
+      let(:req) { Rpc::GetThingRequest.new(params) }
+      let(:method_name) { :GetThing }
+
+      it 'calls the appropriate method with the right signature' do
+        expect(client).to receive(:get_thing).with(
+          an_instance_of(::Rpc::GetThingRequest),
+          { return_op: true, metadata: metadata }
+        ).and_return(op)
+        expect(subject).to be_truthy
+      end
+    end
   end
 
   describe '#build_metadata' do


### PR DESCRIPTION
## What? Why?

Fixes #191. This allows passing the request object directly without first converting it to a hash.

## How was it tested?

Unit tests.