### PR TITLE
Fix Rubocop violations

### DIFF
--- a/lib/gruf/cli/executor.rb
+++ b/lib/gruf/cli/executor.rb
@@ -182,7 +182,7 @@ module Gruf
         # next check CLI arguments
         services = @options[:services].to_s.split(',').map(&:strip).uniq
         # finally, if none, use global gruf autoloaded services
-        services = (::Gruf.services || []) unless services.any?
+        services = ::Gruf.services || [] unless services.any?
 
         services
       end

--- a/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
+++ b/lib/gruf/interceptors/instrumentation/request_logging/interceptor.rb
@@ -108,7 +108,7 @@ module Gruf
           # @return [::Gruf::Logger]
           #
           def logger
-            @logger ||= (options.fetch(:logger, nil) || Gruf.logger)
+            @logger ||= options.fetch(:logger, nil) || Gruf.logger
           end
 
           ##

--- a/lib/gruf/server.rb
+++ b/lib/gruf/server.rb
@@ -192,7 +192,7 @@ module Gruf
     # @return [Array<Class>]
     #
     def services
-      @services ||= (::Gruf.services || (options.fetch(:services, nil) || []))
+      @services ||= ::Gruf.services || (options.fetch(:services, nil) || [])
     end
 
     ##

--- a/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/request_logging/interceptor_spec.rb
@@ -146,7 +146,7 @@ describe Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor do
         it 'supports nested filtering' do
           expected = Marshal.load(Marshal.dump(params))
           expected[:data][:array] = 'REDACTED'
-          expected[:hello].each do |key, _val|
+          expected[:hello].each_key do |key|
             expected[:hello][key] = 'REDACTED'
           end
           expect(subject).to eq expected


### PR DESCRIPTION

## What? Why?

This fixed two following Rubocop violdations.

* Style/RedundantParentheses: Don't use parentheses around a logical expression.
* Style/HashEachMethods: Use each_key instead of each and remove the unused _val block argument.

Ref: https://app.circleci.com/pipelines/github/bigcommerce/gruf/296/workflows/7a6ab822-1868-478d-9d5b-4287b8cb2dcf/jobs/3503


## How was it tested?

