### PR TITLE
Relax ruby requirements

### DIFF
--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'gruf'
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7', '< 3.3'
+  spec.required_ruby_version = '>= 2.7', '< 3.4'
 
   spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/bigcommerce/gruf/issues',


### PR DESCRIPTION
Add ruby 3.3 support

## What? Why?

Ruby 3.3 was released (GA)

## How was it tested?

All tests are green

