### PR TITLE
Add ruby 3.3 support, drop Ruby 2.x support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,6 @@ gem_cache_key: &gem_cache_key
   gem_cache_key: "gem-cache-v2"
 
 executors:
-  ruby_2_7:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.7"
   ruby_3_0:
     <<: *ruby_env
     parameters:
@@ -43,6 +37,12 @@ executors:
       ruby-version:
         type: string
         default: "3.2"
+  ruby_3_3:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.3"
 
 commands:
   pre-setup:
@@ -178,21 +178,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_2_7:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_7-bundle_audit"
-          e: "ruby_2_7"
-      - rubocop:
-          name: "ruby-2_7-rubocop"
-          e: "ruby_2_7"
-      - rspec-unit:
-          name: "ruby-2_7-rspec"
-          e: "ruby_2_7"
-          code-climate: false
-      - e2e:
-          name: "ruby-2_7-e2e"
-          e: "ruby_2_7"
   ruby_3_0:
     jobs:
       - bundle-audit:
@@ -238,3 +223,18 @@ workflows:
       - e2e:
           name: "ruby-3_2-e2e"
           e: "ruby_3_2"
+  ruby_3_3:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_3-bundle_audit"
+          e: "ruby_3_3"
+      - rubocop:
+          name: "ruby-3_3-rubocop"
+          e: "ruby_3_3"
+      - rspec-unit:
+          name: "ruby-3_3-rspec"
+          e: "ruby_3_3"
+          code-climate: false
+      - e2e:
+          name: "ruby-3_3-e2e"
+          e: "ruby_3_3"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@
 ####################################################################################################
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   SuggestExtensions: false
   NewCops: enable
   Exclude:
@@ -69,6 +69,9 @@ Metrics/ParameterLists:
 
 Metrics/PerceivedComplexity:
   Max: 12
+
+Style/ArgumentsForwarding:
+  Enabled: false
 
 ####################################################################################################
 # Naming Configurations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+* [#197] Add support for Ruby 3.3
+* Drop support for Ruby 2.x
+
 ### 2.18.0
 
 * Add `GRUF_USE_DEFAULT_INTERCEPTORS` ENV to dynamically enable/disable default interceptors

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ up fast and efficiently at scale. Some of its features include:
   still preserving gRPC BadStatus codes
 * Server and client execution timings in responses
 
-gruf currently has active support for gRPC 1.10.x+. gruf is compatible and tested with Ruby 2.7-3.2.
+gruf currently has active support for gRPC 1.10.x+. gruf is compatible and tested with Ruby 3.0-3.3.
 gruf is also not [Rails](https://github.com/rails/rails)-specific, and can be used in any Ruby framework
 (such as [Grape](https://github.com/ruby-grape/grape) or [dry-rb](https://dry-rb.org/), for instance).
 

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'gruf'
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7', '< 3.3'
+  spec.required_ruby_version = '>= 3.0', '< 3.4'
 
   spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/bigcommerce/gruf/issues',

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -121,7 +121,7 @@ module Gruf
       }.freeze
     }.freeze
 
-    attr_accessor(* VALID_CONFIG_KEYS.keys)
+    attr_accessor(*VALID_CONFIG_KEYS.keys)
 
     ##
     # Whenever this is extended into a class, setup the defaults
@@ -164,7 +164,7 @@ module Gruf
     #
     def reset
       VALID_CONFIG_KEYS.each do |k, v|
-        send("#{k}=", v)
+        send(:"#{k}=", v)
       end
       self.server_binding_url = "#{::ENV.fetch('GRPC_SERVER_HOST',
                                                '0.0.0.0')}:#{::ENV.fetch('GRPC_SERVER_PORT', 9_001)}"

--- a/lib/gruf/error.rb
+++ b/lib/gruf/error.rb
@@ -88,7 +88,7 @@ module Gruf
       @field_errors = []
       @metadata = {}
       args.each do |k, v|
-        send("#{k}=", v) if respond_to?(k)
+        send(:"#{k}=", v) if respond_to?(k)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ require 'gruf'
 require 'ffaker'
 require 'pry'
 
-Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].sort.each { |f| require f }
+Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   config.mock_with :rspec do |mocks|


### PR DESCRIPTION
## What? Why?

* Adds end-to-end Ruby 3.3 support. Local testing and the end-to-end suite in this repository was performed to ensure performance and grpc gem compatibility. All looks good.
* Drops support for Ruby 2.x, as that reached EOL in Mar 2023.

Unfortunately, grpc still is required to be compiled from source during `bundle install`, which will cause CI suites to timeout. This means this PR is effectively blocked until https://github.com/grpc/grpc/pull/35399 and https://github.com/grpc/grpc/commit/43d2b28e02174d09a64682ef0e65d7dc754f53af is released, and the grpc gem is cross-compiled and bundled.

## How was it tested?

rspec, local performance testing.