### PR TITLE
Fix double loading and Zeitwerk::NameError for symlinked entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+* [#201] Fix double loading of the entry file and Zeitwerk::NameError when the entrypoint is a symlink
+
 ### 2.18.0
 
 * Add `GRUF_USE_DEFAULT_INTERCEPTORS` ENV to dynamically enable/disable default interceptors

--- a/lib/gruf.rb
+++ b/lib/gruf.rb
@@ -22,11 +22,19 @@ require 'active_support/concern'
 require 'active_support/inflector'
 require 'base64'
 
+# defining this module before the loader setup fixes double loading of this
+# entrypoint file if this is a symlink
+module Gruf
+end
+
 # use Zeitwerk to lazily autoload all the files in the lib directory
 require 'zeitwerk'
 loader = ::Zeitwerk::Loader.new
 loader.tag = File.basename(__FILE__, '.rb')
-loader.inflector = ::Zeitwerk::GemInflector.new(__FILE__)
+# __FILE__ returns symlink path if the file is a symlink but __dir__ returns realpath
+# so without realpath of the file, Zeitwerk custom rule for version file
+# will fail in case of symlink
+loader.inflector = ::Zeitwerk::GemInflector.new(File.realpath(__FILE__))
 loader.ignore("#{__dir__}/gruf/integrations/rails/railtie.rb")
 loader.ignore("#{__dir__}/gruf/controllers/health_controller.rb")
 loader.push_dir(__dir__)


### PR DESCRIPTION
## What? Why?

Our build system creates symlink to the installed location of Gems and we `require` that soft link in our application.
Since Gruf setup the loader with `__dir__` which returns realpath (canonicalized absolute path), ruby Autoload considers it as a new Feature when we require the symlink of the entry point, causing it to double load the entry point.

If we define Gruf module before the loader setup, autoloader will not setup autoload for `gruf.rb` and this will fix the problem. Please refer to this [comment](https://github.com/fxn/zeitwerk/issues/282#issuecomment-1902247574) and the issue for more context.

The second error related to this is that the Zeitwerk Inflector has custom rule to detect version file. We setup the inflector with `__FILE__` which uses symlinked path, but the loader receives `__dir__` for the directories/files to autoload, this causes the rule to fail as __dir__ resolves the symlink to return the realpath. Please refer to this [issue](https://github.com/fxn/zeitwerk/issues/284)

I understand that this PR might not be desirable as it's probably affecting very less number of users. Please feel free to close this if it's not worth it.

## How was it tested?

Both `test` and `e2e` scripts passed. Tested in one of my application, all tests green.