### PR TITLE
Update Zeitwerk setup

### DIFF
--- a/lib/gruf.rb
+++ b/lib/gruf.rb
@@ -24,12 +24,10 @@ require 'base64'
 
 # use Zeitwerk to lazily autoload all the files in the lib directory
 require 'zeitwerk'
-loader = ::Zeitwerk::Loader.new
-loader.tag = File.basename(__FILE__, '.rb')
-loader.inflector = ::Zeitwerk::GemInflector.new(__FILE__)
-loader.ignore("#{__dir__}/gruf/integrations/rails/railtie.rb")
-loader.ignore("#{__dir__}/gruf/controllers/health_controller.rb")
-loader.push_dir(__dir__)
+loader = Zeitwerk::Loader.for_gem
+lib = File.dirname(__FILE__)
+loader.ignore("#{lib}/gruf/integrations/rails/railtie.rb")
+loader.ignore("#{lib}/gruf/controllers/health_controller.rb")
 loader.setup
 
 require_relative 'gruf/integrations/rails/railtie' if defined?(::Rails)


### PR DESCRIPTION
## What? Why?

There are three proposed changes.

The main motivation for this patch is that thanks to https://github.com/fxn/zeitwerk/issues/282 and https://github.com/fxn/zeitwerk/issues/284 I have learned `__dir__` is not a good path prefix for setting loaders up, because it is a real path, while `__FILE__` is not. This detail shows up when using symlinks, as it is the case in the project those tickets were about. The proposed code uses `File.dirname(__FILE__)` instead, for cosistency in the involved paths.

Gruf probably copied a snippet from the README that unrolled what `for_gem` does and used `__dir__`, that snippet has been recently updated (https://github.com/fxn/zeitwerk/commit/7daca616ff12f4e8eaf7a36649c4ca78082aa154). However, that snippet is only there for illustration purposes, it is more simple and idiomatic to setup the loader with `for_gem`. So we simplify things a bit with `for_gem`.

Finally, since I was on it, `Zeitwerk` is a top-level constant, there is no reason to use a leading `::` in the top-level of the script. 

## How was it tested?

Using demo apps locally, both auto and eager loading.
