### PR TITLE
Removes manual establish_connection in interceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 * [#190] Remove unsued `e2mmap` and `thwait` gems from `runtime_dependency`.
 * [#194] Add interceptor to reload Rails app code accross requests
+* [#209] Removes manual `establish_connection` and active connection check for each request from `Gruf::Interceptors::ActiveRecord::ConnectionReset`.
 
 ### 2.19.0
 

--- a/lib/gruf/interceptors/active_record/connection_reset.rb
+++ b/lib/gruf/interceptors/active_record/connection_reset.rb
@@ -27,10 +27,6 @@ module Gruf
         # connection pool, we need to ensure that this is done to properly
         #
         def call
-          if enabled?
-            target_classes.each { |klass| klass.establish_connection unless klass.connection.active? }
-          end
-
           yield
         ensure
           target_classes.each(&:clear_active_connections!) if enabled?

--- a/spec/gruf/interceptors/active_record/connection_reset_spec.rb
+++ b/spec/gruf/interceptors/active_record/connection_reset_spec.rb
@@ -33,9 +33,7 @@ describe Gruf::Interceptors::ActiveRecord::ConnectionReset do
       end
 
       it 'tries to clear any active connections' do
-        expect(animals_record).to receive(:establish_connection).and_call_original
         expect(animals_record).to receive(:clear_active_connections!).and_call_original
-        expect(::ActiveRecord::Base).to receive(:establish_connection)
         expect(::ActiveRecord::Base).to receive(:clear_active_connections!)
         subject
       end
@@ -47,9 +45,7 @@ describe Gruf::Interceptors::ActiveRecord::ConnectionReset do
       end
 
       it 'does not try to clear any active connections' do
-        expect(::ActiveRecord::Base).not_to receive(:establish_connection)
         expect(::ActiveRecord::Base).not_to receive(:clear_active_connections!)
-        expect(animals_record).not_to receive(:establish_connection)
         expect(animals_record).not_to receive(:clear_active_connections!)
         subject
       end


### PR DESCRIPTION
## What? 
Removes manual `establish_connection` from the interceptor. It seems like it was added [here](https://github.com/bigcommerce/gruf/pull/31) to support Rails 5.

## Why?
* This should occur automatically if/when during the request processing in the grpc service, ActiveRecord is used to perform a query.
* For when sql server is unavailable. By checking `connection.active?` for each request and subsequently attempting to `establish_connection`, we are currently raising an exception (`Can't connect to MySQL server` etc.) in the interceptor before we can execute the `Check` inside health check endpoints. That seems incorrect.

## How was it tested?
It has been tested against 3 rails versions `[6.1, 7.0, 7.1]` using [gruf-demo repo](https://github.com/bc-amit/gruf-demo/tree/manual_establish_connection_handling_removal). In all three tests, we have a gruf server running and rake task provided in the demo repo is used to exercise the GRPC service that executes sql queries. 

I've recorded videos for testing against all 3 versions. We can see in the tests that sql query gets executed as expected and we are able to view results from the DB without manual connection establishment that comes from the interceptor.

1. 6.1 - [commit](https://github.com/bc-amit/gruf-demo/commit/64b6757fadb0ad6735d7c3af99c1ce6ddc3be3d9) that includes current PR as dependency.

https://github.com/bigcommerce/gruf/assets/107909200/505a9f32-b14e-45fe-bb25-f838e5d3f105


2. 7.0 - [commit](https://github.com/bc-amit/gruf-demo/commit/aef237ade2bb6869186f179d89a7409d91004fb5) that upgrades Rails to version 7.0.

https://github.com/bigcommerce/gruf/assets/107909200/4aeac637-8034-473c-a75f-33f7b6b59d80


3. 7.1 - [commit](https://github.com/bc-amit/gruf-demo/commit/62022c75fd6a406b59d1548fb67c8199ed9cbebd) that upgrades Rails to version 7.1.

https://github.com/bigcommerce/gruf/assets/107909200/39220841-0ad7-4b63-9e95-804200130bc5

