### PR TITLE
Fix deprecation warning in rails `ConnectionReset`

### DIFF
--- a/lib/gruf/interceptors/active_record/connection_reset.rb
+++ b/lib/gruf/interceptors/active_record/connection_reset.rb
@@ -29,7 +29,7 @@ module Gruf
         def call
           yield
         ensure
-          target_classes.each { |klass| klass.connection_handler.clear_active_connections! } if enabled?
+          target_classes.each { |klass| klass.connection_handler.clear_active_connections!(:all) } if enabled?
         end
 
         private


### PR DESCRIPTION
## What? Why?
I saw this deprecation warning in our codebase. 

```
DEPRECATION WARNING: `clear_active_connections!` currently only applies to connection pools in the current role (`writing`). In Rails 7.2, this method will apply to all known pools, regardless of role. To affect only those connections belonging to a specific role, pass the role name as an argument. To switch to the new behavior, pass `:all` as the role name.
```

## How was it tested?
- From my company's internal fork
