### PR TITLE
Fix clear_active_connections! with no argument deprecation warning

### DIFF
--- a/lib/gruf/interceptors/active_record/connection_reset.rb
+++ b/lib/gruf/interceptors/active_record/connection_reset.rb
@@ -29,7 +29,11 @@ module Gruf
         def call
           yield
         ensure
-          target_classes.each { |klass| klass.connection_handler.clear_active_connections! } if enabled?
+          if enabled?
+            target_classes.each do |klass|
+              klass.connection_handler.clear_active_connections!(::ActiveRecord::Base.current_role)
+            end
+          end
         end
 
         private

--- a/spec/support/rails.rb
+++ b/spec/support/rails.rb
@@ -32,6 +32,10 @@ module ActiveRecord
     def self.connected?
       true
     end
+
+    def self.current_role
+      :writing
+    end
   end
 
   class Connection
@@ -45,7 +49,7 @@ module ActiveRecord
   end
 
   class ConnectionHandler
-    def clear_active_connections!
+    def clear_active_connections!(role)
       true
     end
   end


### PR DESCRIPTION
We're using gruf v2.20.1, and still experience the deprecation warning for `clear_active_connections!`.

```
DEPRECATION WARNING: `clear_active_connections!` currently only applies to connection pools in the current role (`reading`).
In Rails 7.2, this method will apply to all known pools, regardless of role. To affect only those connections belonging to a specific role, pass the role name as an argument.
To switch to the new behavior, pass `:all` as the role name. (called from block in call at gruf/lib/gruf/interceptors/active_record/connection_reset.rb:32)>
```

This is caused by rails/rails#45924.

~~If you're still supporting Rails < 7.1, then we should change this to use `ActiveRecord::Base.current_role`, but I thought your goal was to clear any and all active connections -- please correct me if I'm wrong.~~

**EDIT: I think supporting Rails 7.0 is a good idea, but I think you lose the ability to clear those connections in the other pools.**

Due to Gruf::Controllers::Base rewriting the error message, actually the backtrace location was confusing.

Maybe `fail!` could be fixed to include it in the message, but that is beyond the scope of this PR.

Similar to #208 but for a separate deprecation warning when using multiple roles.
