### PR TITLE
Fix some runtime warnings

### DIFF
--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -85,7 +85,7 @@ module Gruf
         t.join
         t.kill
       end
-    rescue StandardError, RuntimeError, Exception => e
+    rescue StandardError, RuntimeError, Exception
       grpc_server&.stop
       t&.join
       t&.kill

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -94,7 +94,6 @@ module Gruf
       grpc_server&.stop
       t&.join
       t&.kill
-      nil
     end
 
     ##


### PR DESCRIPTION
## What? Why?

A runtime warning was output when executing in the following environment, which has been corrected:
```
❯ ruby -v
ruby 3.4.0rc1 (2024-12-12 master 29caae9991) +PRISM [arm64-darwin23]
❯ RUBYOPT=-w bundle exec rake
/ydah/gruf/spec/support/helpers.rb:97: warning: possibly useless use of nil in void context
/ydah/gruf/spec/support/helpers.rb:88: warning: assigned but unused variable - e
```

## How was it tested?

Verified that existing tests were not broken.
