### PR TITLE
Add support for Ruby 3.4 and drop support for EOL Ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,6 @@ gem_cache_key: &gem_cache_key
   gem_cache_key: "gem-cache-v2"
 
 executors:
-  ruby_3_0:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "3.0"
   ruby_3_1:
     <<: *ruby_env
     parameters:
@@ -43,6 +37,12 @@ executors:
       ruby-version:
         type: string
         default: "3.3"
+  ruby_3_4:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.4"
 
 commands:
   pre-setup:
@@ -132,7 +132,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_1"
     steps:
       - pre-setup
       - bundle-install:
@@ -143,7 +143,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_1"
     steps:
       - pre-setup
       - bundle-install:
@@ -154,7 +154,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_1"
       code-climate:
         type: boolean
         default: false
@@ -169,7 +169,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_1"
     steps:
       - pre-setup
       - bundle-install:
@@ -178,21 +178,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_3_0:
-    jobs:
-      - bundle-audit:
-          name: "ruby-3_0-bundle_audit"
-          e: "ruby_3_0"
-      - rubocop:
-          name: "ruby-3_0-rubocop"
-          e: "ruby_3_0"
-      - rspec-unit:
-          name: "ruby-3_0-rspec"
-          e: "ruby_3_0"
-          code-climate: true
-      - e2e:
-          name: "ruby-3_0-e2e"
-          e: "ruby_3_0"
   ruby_3_1:
     jobs:
       - bundle-audit:
@@ -238,3 +223,18 @@ workflows:
       - e2e:
           name: "ruby-3_3-e2e"
           e: "ruby_3_3"
+  ruby_3_4:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_4-bundle_audit"
+          e: "ruby_3_4"
+      - rubocop:
+          name: "ruby-3_4-rubocop"
+          e: "ruby_3_4"
+      - rspec-unit:
+          name: "ruby-3_4-rspec"
+          e: "ruby_3_4"
+          code-climate: true
+      - e2e:
+          name: "ruby-3_4-e2e"
+          e: "ruby_3_4"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@
 ####################################################################################################
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   SuggestExtensions: false
   NewCops: enable
   Exclude:
@@ -78,6 +78,9 @@ Style/ArgumentsForwarding:
 ####################################################################################################
 
 Naming/PredicateName:
+  Enabled: false
+
+Naming/BlockForwarding:
   Enabled: false
 
 ####################################################################################################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+* [#224] Add support for Ruby 3.4 and drop support for EOL Ruby 3.0
+
 ### 2.20.1
 
 * [#208] Fix rails `clear_active_connections!` deprecation warning

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ up fast and efficiently at scale. Some of its features include:
   still preserving gRPC BadStatus codes
 * Server and client execution timings in responses
 
-gruf currently has active support for gRPC 1.10.x+. gruf is compatible and tested with Ruby 3.0-3.3.
+gruf currently has active support for gRPC 1.10.x+. gruf is compatible and tested with Ruby 3.1-3.4.
 gruf is also not [Rails](https://github.com/rails/rails)-specific, and can be used in any Ruby framework
 (such as [Grape](https://github.com/ruby-grape/grape) or [dry-rb](https://dry-rb.org/), for instance).
 

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables << 'gruf'
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 3.0', '< 3.4'
+  spec.required_ruby_version = '>= 3.1', '< 3.5'
 
   spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/bigcommerce/gruf/issues',


### PR DESCRIPTION
## What? Why?

Adding support for Ruby 3.4, removing support for EOL Ruby 3.0, and adding one RuboCop config entry as with bumping to min Ruby version 3.1 in RuboCop config we've encountered a new default cop that will rename all `&block` to just `&` which I don't think is desirable. Please let me know if we're fine with that change, shown in part below.

<img width="1920" alt="Screenshot 2025-01-29 at 19 45 38 (2)" src="https://github.com/user-attachments/assets/08219415-706b-44cf-9006-dbcbd41c22db" />

Resolves https://github.com/bigcommerce/gruf/issues/223

## How was it tested?

This was primary just run through the test suite. Beyond that I tested the updated version can be `bundle install`-ed on a Ruby 3.4.1 application. Though haven't been able to actually run such yet as that application has other gems that need to be updated. :grimacing: 