### PR TITLE
Support multiple controllers path

### DIFF
--- a/lib/gruf/autoloaders.rb
+++ b/lib/gruf/autoloaders.rb
@@ -24,11 +24,16 @@ module Gruf
       include Enumerable
 
       ##
-      # Initialize the autoloaders with a given controllers paths
+      # Initialize the autoloaders with given controllers paths
       #
+      # @param [String] controllers_path The path to Gruf Controllers
       # @param [Array<String>] controllers_paths The path to Gruf Controllers
       #
-      def load!(controllers_paths:)
+      def load!(controllers_path: nil, controllers_paths: [])
+        if controllers_path
+          ::Gruf.logger.warn('controllers_path is deprecated. Please use controllers_paths instead.')
+          controllers_paths = [controllers_path]
+        end
         controllers(controllers_paths: controllers_paths)
       end
 
@@ -53,8 +58,9 @@ module Gruf
       #
       # rubocop:disable ThreadSafety/ClassInstanceVariable
       def controllers(controllers_paths: [])
+        controllers_paths = ::Gruf.controllers_paths if controllers_paths.empty?
         controllers_mutex do
-          @controllers ||= ::Gruf::Controllers::Autoloader.new(paths: controllers_paths || ::Gruf.controllers_paths)
+          @controllers ||= ::Gruf::Controllers::Autoloader.new(paths: controllers_paths)
         end
       end
       # rubocop:enable ThreadSafety/ClassInstanceVariable

--- a/lib/gruf/autoloaders.rb
+++ b/lib/gruf/autoloaders.rb
@@ -24,12 +24,12 @@ module Gruf
       include Enumerable
 
       ##
-      # Initialize the autoloaders with a given controllers path
+      # Initialize the autoloaders with a given controllers paths
       #
-      # @param [String] controllers_path The path to Gruf Controllers
+      # @param [Array<String>] controllers_paths The path to Gruf Controllers
       #
-      def load!(controllers_path:)
-        controllers(controllers_path: controllers_path)
+      def load!(controllers_paths:)
+        controllers(controllers_paths: controllers_paths)
       end
 
       ##
@@ -52,9 +52,9 @@ module Gruf
       # @return [::Gruf::Controllers::Autoloader]
       #
       # rubocop:disable ThreadSafety/ClassInstanceVariable
-      def controllers(controllers_path: nil)
+      def controllers(controllers_paths: [])
         controllers_mutex do
-          @controllers ||= ::Gruf::Controllers::Autoloader.new(path: controllers_path || ::Gruf.controllers_path)
+          @controllers ||= ::Gruf::Controllers::Autoloader.new(paths: controllers_paths || ::Gruf.controllers_paths)
         end
       end
       # rubocop:enable ThreadSafety/ClassInstanceVariable

--- a/lib/gruf/cli/executor.rb
+++ b/lib/gruf/cli/executor.rb
@@ -119,7 +119,7 @@ module Gruf
       #
       def register_services!
         # wait to load controllers until last possible second to allow late configuration
-        ::Gruf.autoloaders.load!(controllers_path: Gruf.controllers_path)
+        ::Gruf.autoloaders.load!(controllers_paths: Gruf.controllers_paths)
 
         services = determine_services(@services)
         services = bind_health_check!(services) if health_check_enabled?

--- a/lib/gruf/client.rb
+++ b/lib/gruf/client.rb
@@ -159,7 +159,7 @@ module Gruf
     #
     def request_object(request_method, params = {})
       desc = rpc_desc(request_method)
-      desc&.input ? desc.input.new(params) : nil
+      desc&.input&.new(params)
     end
 
     ##

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -44,6 +44,8 @@ module Gruf
     #   @return [String] If use_ssl is true, the relative path from the root_path to the key file for the server
     # @!attribute controllers_path
     #   @return [String] The relative path from root_path to locate Gruf Controllers in
+    # @!attribute controllers_paths
+    #   @return [Array<String>] The relative paths from root_path to locate Gruf Controllers in
     # @!attribute services
     #   @return [Array<Class>] An array of services to serve with this Gruf server
     # @!attribute logger
@@ -96,6 +98,7 @@ module Gruf
       ssl_crt_file: '',
       ssl_key_file: '',
       controllers_path: '',
+      controllers_paths: [],
       services: [],
       logger: nil,
       grpc_logger: nil,
@@ -176,6 +179,7 @@ module Gruf
       self.ssl_key_file = "#{root_path}config/ssl/#{environment}.key"
       cp = ::ENV.fetch('GRUF_CONTROLLERS_PATH', 'app/rpc').to_s
       self.controllers_path = root_path.to_s.empty? ? cp : "#{root_path}/#{cp}"
+      self.controllers_paths = [self.controllers_path]
       self.backtrace_on_error = ::ENV.fetch('GRPC_BACKTRACE_ON_ERROR', 0).to_i.positive?
       self.rpc_server_options = {
         max_waiting_requests: ::ENV.fetch('GRPC_SERVER_MAX_WAITING_REQUESTS',

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -179,7 +179,7 @@ module Gruf
       self.ssl_key_file = "#{root_path}config/ssl/#{environment}.key"
       cp = ::ENV.fetch('GRUF_CONTROLLERS_PATH', 'app/rpc').to_s
       self.controllers_path = root_path.to_s.empty? ? cp : "#{root_path}/#{cp}"
-      self.controllers_paths = [self.controllers_path]
+      self.controllers_paths = [controllers_path]
       self.backtrace_on_error = ::ENV.fetch('GRPC_BACKTRACE_ON_ERROR', 0).to_i.positive?
       self.rpc_server_options = {
         max_waiting_requests: ::ENV.fetch('GRPC_SERVER_MAX_WAITING_REQUESTS',

--- a/lib/gruf/hooks/registry.rb
+++ b/lib/gruf/hooks/registry.rb
@@ -90,7 +90,7 @@ module Gruf
           raise HookNotFoundError if pos.nil?
 
           @registry.insert(
-            (pos + 1),
+            pos + 1,
             klass: hook_class,
             options: options
           )

--- a/lib/gruf/integrations/rails/railtie.rb
+++ b/lib/gruf/integrations/rails/railtie.rb
@@ -26,10 +26,10 @@ module Gruf
           config.before_configuration do
             # Remove autoloading of the controllers path from Rails' zeitwerk, so that we ensure Gruf's zeitwerk
             # properly manages them itself. This allows us to manage code reloading and logging in Gruf specifically
-            app.config.eager_load_paths -= [::Gruf.controllers_path] if app.config.respond_to?(:eager_load_paths)
+            app.config.eager_load_paths -= ::Gruf.controllers_paths if app.config.respond_to?(:eager_load_paths)
             if ::Rails.respond_to?(:autoloaders) # if we're on a late enough version of rails
               ::Rails.autoloaders.each do |autoloader|
-                autoloader.ignore(Gruf.controllers_path)
+                autoloader.ignore(Gruf.controllers_paths)
               end
             end
           end

--- a/lib/gruf/interceptors/registry.rb
+++ b/lib/gruf/interceptors/registry.rb
@@ -90,7 +90,7 @@ module Gruf
           raise InterceptorNotFoundError if pos.nil?
 
           @registry.insert(
-            (pos + 1),
+            pos + 1,
             klass: interceptor_class,
             options: options
           )

--- a/lib/gruf/server.rb
+++ b/lib/gruf/server.rb
@@ -203,6 +203,13 @@ module Gruf
     end
 
     ##
+    # @param [Array<String>]
+    #
+    def controllers_paths
+      options.fetch(:controllers_paths, Gruf.controllers_paths)
+    end
+
+    ##
     # Load the SSL/TLS credentials for this server
     #
     # @return [GRPC::Core::ServerCredentials|Symbol]

--- a/spec/gruf/autoloaders_spec.rb
+++ b/spec/gruf/autoloaders_spec.rb
@@ -29,6 +29,22 @@ describe Gruf::Autoloaders do
       expect(autoloaders.controllers).to be_a(::Gruf::Controllers::Autoloader)
       expect(autoloaders.controllers.paths).to eq [controllers_path]
     end
+
+    context 'when deprecated controllers_path is passed' do
+      subject { autoloaders.load!(controllers_path: controllers_path) }
+
+      it 'creates a controller autoloader for the passed path' do
+        subject
+        expect(autoloaders.controllers).to be_a(::Gruf::Controllers::Autoloader)
+        expect(autoloaders.controllers.paths).to eq [controllers_path]
+      end
+
+      it 'logs a deprecation warning' do
+        expect(::Gruf.logger)
+          .to receive(:warn).with('controllers_path is deprecated. Please use controllers_paths instead.')
+        subject
+      end
+    end
   end
 
   describe '#each' do

--- a/spec/gruf/autoloaders_spec.rb
+++ b/spec/gruf/autoloaders_spec.rb
@@ -22,12 +22,12 @@ describe Gruf::Autoloaders do
   let(:controllers_path) { 'spec/pb' }
 
   describe '#load!' do
-    subject { autoloaders.load!(controllers_path: controllers_path) }
+    subject { autoloaders.load!(controllers_paths: [controllers_path]) }
 
     it 'creates a controller autoloader for the passed path' do
       subject
       expect(autoloaders.controllers).to be_a(::Gruf::Controllers::Autoloader)
-      expect(autoloaders.controllers.path).to eq controllers_path
+      expect(autoloaders.controllers.paths).to eq [controllers_path]
     end
   end
 
@@ -41,7 +41,7 @@ describe Gruf::Autoloaders do
     subject { autoloaders.reload }
 
     before do
-      autoloaders.load!(controllers_path: controllers_path)
+      autoloaders.load!(controllers_paths: [controllers_path])
     end
 
     it 'runs reload on all autoloaders' do

--- a/spec/gruf/controllers/autoloader_spec.rb
+++ b/spec/gruf/controllers/autoloader_spec.rb
@@ -21,7 +21,7 @@ describe ::Gruf::Controllers::Autoloader do
   let(:path) { 'spec/pb' }
   let(:reloading) { nil }
   let(:tag) { 'gruf-controllers' }
-  let(:autoloader) { described_class.new(path: path, reloading: reloading) }
+  let(:autoloader) { described_class.new(paths: [path], reloading: reloading) }
   let(:zeitwerk) do
     instance_spy(::Zeitwerk::Loader, setup: true, 'tag=': tag, tag: tag, ignore: true, push_dir: true, eager_load: true)
   end


### PR DESCRIPTION
## What? Why?

I ran into a problem in a Rails app which was made up of multiple Rails engines. The problem was that two engines were using Gruf and when they were used in same Rails app, the Gruf config for `controllers_path` was getting overridden.

So to fix that problem, I patched Gruf to support multiple paths for controllers by adding a new config field `controllers_paths`. This field defaults to `[controllers_path]`. Gruf uses this `controllers_paths` instead of `controllers_path` everywhere, but `controllers_path` is kept in config for backward compatibility.

Note: I think the config should support something like `add_controllers_paths`, instead of directly setting `controllers_paths`. That will allow multiple modules to add their controllers path without messing with the existing paths. Let me know if you like this idea, I will update the PR

## How was it tested?

All the specs are passing