### PR TITLE
Add fix for load order issues with reloader in some non-Rails environments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ AllCops:
     - spec/fixtures/**/*
     - spec/pb/**/*
     - spec/demo_server
-require:
+plugins:
   - rubocop-performance
   - rubocop-rspec
   - rubocop-thread_safety
@@ -77,7 +77,7 @@ Style/ArgumentsForwarding:
 # Naming Configurations
 ####################################################################################################
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: false
 
 ####################################################################################################

--- a/lib/gruf/client.rb
+++ b/lib/gruf/client.rb
@@ -156,20 +156,24 @@ module Gruf
     # @param [Symbol] request_method The method name being called on the remote service
     # @param [Hash] params (Optional) A hash of parameters that will populate the request object
     # @return [Class] The request object that corresponds to the method being called
+    # @return [NilClass] if the descriptor is not found or the input is not defined
     #
     def request_object(request_method, params = {})
       desc = rpc_desc(request_method)
-      desc&.input ? desc.input.new(params) : nil
+      desc&.input&.new(params)
     end
 
     ##
     # Properly find the appropriate call signature for the GRPC::GenericService given the request method name
     #
     # @return [Symbol]
+    # @return [NilClass] If the descriptor is not found
     #
     def call_signature(request_method)
       desc = rpc_desc(request_method)
-      desc&.name ? desc.name.to_s.underscore.to_sym : nil
+      return nil unless desc
+
+      desc.name.to_s.underscore.to_sym
     end
 
     ##

--- a/lib/gruf/configuration.rb
+++ b/lib/gruf/configuration.rb
@@ -189,8 +189,8 @@ module Gruf
       self.use_default_interceptors = ::ENV.fetch('GRUF_USE_DEFAULT_INTERCEPTORS', 1).to_i.positive?
 
       if use_default_interceptors
-        if defined?(::Rails)
-          interceptors.use(::Gruf::Interceptors::Rails::Reloader, reloader: Rails.application.reloader)
+        if defined?(::Rails) && ::Rails.respond_to?(:application) && ::Rails.application.respond_to?(:reloader)
+          interceptors.use(::Gruf::Interceptors::Rails::Reloader, reloader: ::Rails.application.reloader)
         end
         interceptors.use(::Gruf::Interceptors::ActiveRecord::ConnectionReset)
         interceptors.use(::Gruf::Interceptors::Instrumentation::OutputMetadataTimer)

--- a/lib/gruf/hooks/registry.rb
+++ b/lib/gruf/hooks/registry.rb
@@ -90,7 +90,7 @@ module Gruf
           raise HookNotFoundError if pos.nil?
 
           @registry.insert(
-            (pos + 1),
+            pos + 1,
             klass: hook_class,
             options: options
           )

--- a/lib/gruf/interceptors/registry.rb
+++ b/lib/gruf/interceptors/registry.rb
@@ -90,7 +90,7 @@ module Gruf
           raise InterceptorNotFoundError if pos.nil?
 
           @registry.insert(
-            (pos + 1),
+            pos + 1,
             klass: interceptor_class,
             options: options
           )

--- a/spec/gruf/interceptors/instrumentation/statsd_spec.rb
+++ b/spec/gruf/interceptors/instrumentation/statsd_spec.rb
@@ -26,7 +26,8 @@ describe Gruf::Interceptors::Instrumentation::Statsd do
   let(:errors) { build(:error) }
   let(:interceptor) { described_class.new(request, errors, options) }
 
-  let(:expected_route_key) { "#{prefix ? "#{prefix}." : ''}rpc.thing_service.get_thing" }
+  let(:method_prefix) { prefix ? "#{prefix}." : '' }
+  let(:expected_route_key) { "#{method_prefix}rpc.thing_service.get_thing" }
 
   describe '#call' do
     subject { interceptor.call { true } }


### PR DESCRIPTION
## What? Why?

In certain non-rails environments that utilize Active* gems, `Rails` may be defined, but not initialized yet, and `Rails.application` will return `nil`. This adjusts the behavior of the default interceptor loading to more defensively check for this case. In those situations, the client can decide when is the appropriate time to load the reloader interceptor.

Also fixes some rubocop errors.

## How was it tested?

E2E suite passes as expected, and tests in a local service show the app booting as expected now post fix:

```
{"message":"[gruf] Starting gruf server at 0.0.0.0:9321...","@timestamp":"2025-06-25T15:05:24.160-05:00","@version":"1","severity":"INFO","thread_id":3976}
```
