### PR TITLE
Add Ruby 4.x support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,12 @@ executors:
       ruby-version:
         type: string
         default: "3.4"
+  ruby_4_0:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "4.0"
 
 commands:
   pre-setup:
@@ -259,3 +265,18 @@ workflows:
       - e2e:
           name: "ruby-3_4-e2e"
           e: "ruby_3_4"
+  ruby_4_0:
+    jobs:
+      - bundle-audit:
+          name: "ruby-4_0-bundle_audit"
+          e: "ruby_4_0"
+      - rubocop:
+          name: "ruby-4_0-rubocop"
+          e: "ruby_4_0"
+      - rspec-unit:
+          name: "ruby-4_0-rspec"
+          e: "ruby_4_0"
+          code-climate: false
+      - e2e:
+          name: "ruby-4_0-e2e"
+          e: "ruby_4_0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the gruf gem. This includes internal history before the gem was ma
 
 ### Pending release
 
+### 2.22.0
+
+* Add support for Ruby 4.x
+
 ### 2.21.2
 
 * [#225] Only replace `.service` as a suffix in `service_key`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ up fast and efficiently at scale. Some of its features include:
   still preserving gRPC BadStatus codes
 * Server and client execution timings in responses
 
-gruf currently has active support for gRPC 1.10.x+. gruf is compatible and tested with Ruby 3.0-3.4.
+gruf currently has active support for gRPC 1.10.x+. gruf is compatible and tested with Ruby 3.x-4.0.
 gruf is also not [Rails](https://github.com/rails/rails)-specific, and can be used in any Ruby framework
 (such as [Grape](https://github.com/ruby-grape/grape) or [dry-rb](https://dry-rb.org/), for instance).
 

--- a/gruf.gemspec
+++ b/gruf.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   # supported by grpc gem before bumping the maximum Ruby major version that this gem officially supports.
   # grpc gem has a history of lagging behind the latest Ruby version support post-new-year every year.
   # See: https://github.com/bigcommerce/gruf/pull/221#issuecomment-2573428792
-  spec.required_ruby_version = '>= 3.0', '< 3.5'
+  spec.required_ruby_version = '>= 3.0', '< 5.0'
 
   spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/bigcommerce/gruf/issues',

--- a/spec/gruf/client/error_factory_spec.rb
+++ b/spec/gruf/client/error_factory_spec.rb
@@ -40,7 +40,7 @@ describe Gruf::Client::ErrorFactory do
       Gruf::Client::Errors.constants
                           .reject { |e| rejected_exceptions.include?(e) }
                           .each do |error_class|
-                            context "and is a GRPC::#{error_class} exception" do
+                            context "when is a GRPC::#{error_class} exception" do
                               let(:exception) { "GRPC::#{error_class}".constantize.new(error_message) }
                               let(:expected_class) { "Gruf::Client::Errors::#{error_class}".constantize }
 


### PR DESCRIPTION
## What? Why?

Loosens the pin for Ruby 4.x support, and adds a CircleCI test suite for it.

## How was it tested?

Locally via `./script/e2e` and through CI tests.

```
➜  ./script/e2e
Beginning full e2e test...
Installing gems...
Bundle complete! 16 Gemfile dependencies, 61 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
Starting gruf server...
D, [2026-01-07T16:22:56.967303 #50464] DEBUG -- : [gruf] Binding Grpc::Health::V1::Health::Service to Gruf::Controllers::HealthController
I, [2026-01-07T16:22:56.967384 #50464]  INFO -- : Executing before server start hook...
I, [2026-01-07T16:22:56.967451 #50464]  INFO -- : [gruf] Starting gruf server at localhost:8001...
Running unary test...
D, [2026-01-07T16:23:01.626468 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::ActiveRecord::ConnectionReset
D, [2026-01-07T16:23:01.626495 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::OutputMetadataTimer
D, [2026-01-07T16:23:01.626727 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::Statsd
D, [2026-01-07T16:23:01.626763 #50464] DEBUG -- : statsd.increment: demo.rpc.thing_service.get_thing
D, [2026-01-07T16:23:01.626772 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Authentication::Basic
D, [2026-01-07T16:23:01.626802 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor
D, [2026-01-07T16:23:01.626817 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::ActiveRecord::ConnectionReset
D, [2026-01-07T16:23:01.629375 #50464] DEBUG -- : [GRPC::Ok] (get_thing) [1.83ms] [GRPC::Ok] (rpc.thing_service.get_thing) Parameters: {id: 77834}
D, [2026-01-07T16:23:01.629410 #50464] DEBUG -- : statsd.increment: demo.rpc.thing_service.get_thing.success
D, [2026-01-07T16:23:01.629423 #50464] DEBUG -- : statsd.timing: demo.rpc.thing_service.get_thing -> 2.626
I, [2026-01-07T16:23:01.629958 #50480]  INFO -- : Got response from server in client interceptor rpc.thing_service.get_thing of type request_response: 8.48ms
I, [2026-01-07T16:23:01.630432 #50480]  INFO -- : <Rpc::GetThingResponse: thing: <Rpc::Thing: id: 77834, name: "Genaro">>
Running server streamer test...
I, [2026-01-07T16:23:01.923820 #50481]  INFO -- : Got response from server in client interceptor rpc.thing_service.get_things of type server_streamer: 1.79ms
D, [2026-01-07T16:23:01.924367 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::ActiveRecord::ConnectionReset
D, [2026-01-07T16:23:01.924388 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::OutputMetadataTimer
D, [2026-01-07T16:23:01.924397 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::Statsd
D, [2026-01-07T16:23:01.924418 #50464] DEBUG -- : statsd.increment: demo.rpc.thing_service.get_things
D, [2026-01-07T16:23:01.924422 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Authentication::Basic
D, [2026-01-07T16:23:01.924442 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor
D, [2026-01-07T16:23:01.924451 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::ActiveRecord::ConnectionReset
D, [2026-01-07T16:23:01.924506 #50464] DEBUG -- : [GRPC::Ok] (get_things) [0.01ms] [GRPC::Ok] (rpc.thing_service.get_things) Parameters: {}
D, [2026-01-07T16:23:01.924517 #50464] DEBUG -- : statsd.increment: demo.rpc.thing_service.get_things.success
D, [2026-01-07T16:23:01.924527 #50464] DEBUG -- : statsd.timing: demo.rpc.thing_service.get_things -> 0.09000000000000001
I, [2026-01-07T16:23:01.925481 #50481]  INFO -- : <Rpc::Thing: id: 630, name: "sint">
I, [2026-01-07T16:23:02.931813 #50481]  INFO -- : <Rpc::Thing: id: 284, name: "quibusdam">
I, [2026-01-07T16:23:03.936024 #50481]  INFO -- : <Rpc::Thing: id: 1000, name: "maxime">
I, [2026-01-07T16:23:04.938886 #50481]  INFO -- : <Rpc::Thing: id: 46, name: "quaerat">
I, [2026-01-07T16:23:05.941877 #50481]  INFO -- : <Rpc::Thing: id: 755, name: "voluptate">
Running client streamer test...
I, [2026-01-07T16:23:06.247122 #50489]  INFO -- : Sending: <Rpc::Thing: id: 761, name: "necessitatibus">
D, [2026-01-07T16:23:06.247389 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::ActiveRecord::ConnectionReset
D, [2026-01-07T16:23:06.247414 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::OutputMetadataTimer
D, [2026-01-07T16:23:06.247426 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::Statsd
D, [2026-01-07T16:23:06.247456 #50464] DEBUG -- : statsd.increment: demo.rpc.thing_service.create_things
D, [2026-01-07T16:23:06.247462 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Authentication::Basic
D, [2026-01-07T16:23:06.247481 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor
D, [2026-01-07T16:23:06.247492 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::ActiveRecord::ConnectionReset
I, [2026-01-07T16:23:07.252437 #50489]  INFO -- : Sending: <Rpc::Thing: id: 975, name: "minima">
I, [2026-01-07T16:23:07.252771 #50489]  INFO -- : Sending: <Rpc::Thing: id: 547, name: "recusandae">
I, [2026-01-07T16:23:08.255410 #50489]  INFO -- : Sending: <Rpc::Thing: id: 924, name: "odit">
I, [2026-01-07T16:23:08.256680 #50489]  INFO -- : Sending: <Rpc::Thing: id: 187, name: "iusto">
I, [2026-01-07T16:23:08.256788 #50489]  INFO -- : Sending: <Rpc::Thing: id: 80, name: "reprehenderit">
I, [2026-01-07T16:23:08.256865 #50489]  INFO -- : Sending: <Rpc::Thing: id: 801, name: "eius">
I, [2026-01-07T16:23:08.256964 #50489]  INFO -- : Sending: <Rpc::Thing: id: 641, name: "vero">
I, [2026-01-07T16:23:09.259980 #50489]  INFO -- : Sending: <Rpc::Thing: id: 879, name: "ut">
I, [2026-01-07T16:23:10.264968 #50489]  INFO -- : Sending: <Rpc::Thing: id: 841, name: "dignissimos">
D, [2026-01-07T16:23:10.265972 #50464] DEBUG -- : [GRPC::Ok] (create_things) [4018.07ms] Parameters: {}
D, [2026-01-07T16:23:10.266092 #50464] DEBUG -- : statsd.increment: demo.rpc.thing_service.create_things.success
D, [2026-01-07T16:23:10.266133 #50464] DEBUG -- : statsd.timing: demo.rpc.thing_service.create_things -> 4018.598
I, [2026-01-07T16:23:10.267034 #50489]  INFO -- : Got response from server in client interceptor rpc.thing_service.create_things of type client_streamer: 4022.02ms
I, [2026-01-07T16:23:10.268215 #50489]  INFO -- : <Rpc::CreateThingsResponse: things: [<Rpc::Thing: id: 761, name: "illo">, <Rpc::Thing: id: 975, name: "cumque">, <Rpc::Thing: id: 547, name: "provident">, <Rpc::Thing: id: 924, name: "possimus">, <Rpc::Thing: id: 187, name: "quibusdam">, <Rpc::Thing: id: 80, name: "culpa">, <Rpc::Thing: id: 801, name: "nulla">, <Rpc::Thing: id: 641, name: "sit">, <Rpc::Thing: id: 879, name: "corrupti">, <Rpc::Thing: id: 841, name: "provident">]>
Running bidi streamer test...
I, [2026-01-07T16:23:10.584087 #50495]  INFO -- : Got response from server in client interceptor rpc.thing_service.create_things_in_stream of type bidi_streamer: 1.54ms
D, [2026-01-07T16:23:10.584667 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::ActiveRecord::ConnectionReset
D, [2026-01-07T16:23:10.584688 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::OutputMetadataTimer
D, [2026-01-07T16:23:10.584696 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::Statsd
D, [2026-01-07T16:23:10.584717 #50464] DEBUG -- : statsd.increment: demo.rpc.thing_service.create_things_in_stream
D, [2026-01-07T16:23:10.584724 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Authentication::Basic
D, [2026-01-07T16:23:10.584742 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor
D, [2026-01-07T16:23:10.584752 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::ActiveRecord::ConnectionReset
D, [2026-01-07T16:23:10.584790 #50464] DEBUG -- : [GRPC::Ok] (create_things_in_stream) [0.01ms] Parameters: {}
D, [2026-01-07T16:23:10.584801 #50464] DEBUG -- : statsd.increment: demo.rpc.thing_service.create_things_in_stream.success
D, [2026-01-07T16:23:10.584810 #50464] DEBUG -- : statsd.timing: demo.rpc.thing_service.create_things_in_stream -> 0.073
I, [2026-01-07T16:23:11.589941 #50495]  INFO -- : Sending: <Rpc::Thing: id: 130, name: "maxime">
I, [2026-01-07T16:23:11.590571 #50495]  INFO -- : Received: <Rpc::Thing: id: 130, name: "maxime">
I, [2026-01-07T16:23:12.590765 #50495]  INFO -- : Sending: <Rpc::Thing: id: 242, name: "laboriosam">
I, [2026-01-07T16:23:12.594745 #50495]  INFO -- : Received: <Rpc::Thing: id: 242, name: "laboriosam">
I, [2026-01-07T16:23:13.596022 #50495]  INFO -- : Sending: <Rpc::Thing: id: 312, name: "facere">
I, [2026-01-07T16:23:13.596791 #50495]  INFO -- : Sending: <Rpc::Thing: id: 953, name: "unde">
I, [2026-01-07T16:23:13.597316 #50495]  INFO -- : Received: <Rpc::Thing: id: 312, name: "facere">
I, [2026-01-07T16:23:14.600419 #50495]  INFO -- : Sending: <Rpc::Thing: id: 538, name: "perspiciatis">
I, [2026-01-07T16:23:14.600624 #50495]  INFO -- : Sending: <Rpc::Thing: id: 585, name: "maxime">
I, [2026-01-07T16:23:14.600909 #50495]  INFO -- : Received: <Rpc::Thing: id: 953, name: "unde">
I, [2026-01-07T16:23:15.603446 #50495]  INFO -- : Sending: <Rpc::Thing: id: 831, name: "illum">
I, [2026-01-07T16:23:15.603870 #50495]  INFO -- : Sending: <Rpc::Thing: id: 353, name: "et">
I, [2026-01-07T16:23:15.604309 #50495]  INFO -- : Received: <Rpc::Thing: id: 538, name: "perspiciatis">
I, [2026-01-07T16:23:15.604367 #50495]  INFO -- : Received: <Rpc::Thing: id: 585, name: "maxime">
I, [2026-01-07T16:23:15.604827 #50495]  INFO -- : Received: <Rpc::Thing: id: 831, name: "illum">
I, [2026-01-07T16:23:15.604877 #50495]  INFO -- : Received: <Rpc::Thing: id: 353, name: "et">
I, [2026-01-07T16:23:16.608772 #50495]  INFO -- : Sending: <Rpc::Thing: id: 70, name: "tempore">
I, [2026-01-07T16:23:16.609687 #50495]  INFO -- : Received: <Rpc::Thing: id: 70, name: "tempore">
I, [2026-01-07T16:23:17.611213 #50495]  INFO -- : Sending: <Rpc::Thing: id: 987, name: "quod">
I, [2026-01-07T16:23:17.611573 #50495]  INFO -- : Received: <Rpc::Thing: id: 987, name: "quod">
Running health check test...
D, [2026-01-07T16:23:17.941912 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::ActiveRecord::ConnectionReset
D, [2026-01-07T16:23:17.941939 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::OutputMetadataTimer
D, [2026-01-07T16:23:17.941948 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::Statsd
D, [2026-01-07T16:23:17.941972 #50464] DEBUG -- : statsd.increment: demo.grpc.health.v1.health.check
D, [2026-01-07T16:23:17.941977 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Authentication::Basic
D, [2026-01-07T16:23:17.941998 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::Instrumentation::RequestLogging::Interceptor
D, [2026-01-07T16:23:17.942008 #50464] DEBUG -- : Intercepting request with interceptor: Gruf::Interceptors::ActiveRecord::ConnectionReset
D, [2026-01-07T16:23:17.942064 #50464] DEBUG -- : [GRPC::Ok] (check) [0.02ms] [GRPC::Ok] (grpc.health.v1.health.check) Parameters: {}
D, [2026-01-07T16:23:17.942075 #50464] DEBUG -- : statsd.increment: demo.grpc.health.v1.health.check.success
D, [2026-01-07T16:23:17.942086 #50464] DEBUG -- : statsd.timing: demo.grpc.health.v1.health.check -> 0.094
I, [2026-01-07T16:23:17.942305 #50503]  INFO -- : Got response from server in client interceptor grpc.health.v1.health.check of type request_response: 2.62ms
I, [2026-01-07T16:23:17.942565 #50503]  INFO -- : <Grpc::Health::V1::HealthCheckResponse: status: :SERVING>
Tests successful! Shutting down server...
Server shutdown, E2E test finished successfully.
```